### PR TITLE
Add support for multiple module decorators

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -20,8 +20,10 @@ import (
 // automatic metrics collection and/or status reporting in the future.
 var Cell = cell.Module(
 	"jobs",
-	"Jobs",
-	cell.Provide(newRegistry),
+	"Managed background goroutines and timers",
+	cell.Provide(
+		newRegistry,
+	),
 )
 
 // A Registry creates Groups, it maintains references to these groups for the purposes of collecting information


### PR DESCRIPTION
This allows having "optional" decorators that won't be called. This is primarily needed for providing a "job.Group" for each module without creating the group and adding it to the lifecycle if it is not used.