### PR TITLE
hive: Add option to reduce trace logging

### DIFF
--- a/cell/cell.go
+++ b/cell/cell.go
@@ -5,6 +5,7 @@ package cell
 
 import (
 	"log/slog"
+	"time"
 
 	"go.uber.org/dig"
 )
@@ -23,7 +24,7 @@ type Cell interface {
 	Info(container) Info
 
 	// Apply the cell to the dependency graph container.
-	Apply(*slog.Logger, container) error
+	Apply(*slog.Logger, container, time.Duration) error
 }
 
 // In when embedded into a struct used as constructor parameter makes the exported

--- a/cell/config.go
+++ b/cell/config.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/cilium/hive/internal"
 	"github.com/mitchellh/mapstructure"
@@ -145,7 +146,7 @@ func decoderConfig(target any, extraHooks DecodeHooks) *mapstructure.DecoderConf
 	}
 }
 
-func (c *config[Cfg]) Apply(log *slog.Logger, cont container) error {
+func (c *config[Cfg]) Apply(log *slog.Logger, cont container, logThreshold time.Duration) error {
 	// Register the flags to the global set of all flags.
 	err := cont.Invoke(
 		func(allFlags *pflag.FlagSet) {

--- a/cell/decorator.go
+++ b/cell/decorator.go
@@ -6,6 +6,7 @@ package cell
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/cilium/hive/internal"
 )
@@ -39,14 +40,14 @@ type decorator struct {
 	cells     []Cell
 }
 
-func (d *decorator) Apply(log *slog.Logger, c container) error {
+func (d *decorator) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
 	scope := c.Scope(fmt.Sprintf("(decorate %s)", internal.PrettyType(d.decorator)))
 	if err := scope.Decorate(d.decorator); err != nil {
 		return err
 	}
 
 	for _, cell := range d.cells {
-		if err := cell.Apply(log, scope); err != nil {
+		if err := cell.Apply(log, scope, logThreshold); err != nil {
 			return err
 		}
 	}

--- a/cell/group.go
+++ b/cell/group.go
@@ -3,7 +3,10 @@
 
 package cell
 
-import "log/slog"
+import (
+	"log/slog"
+	"time"
+)
 
 type group []Cell
 
@@ -13,9 +16,9 @@ func Group(cells ...Cell) Cell {
 	return group(cells)
 }
 
-func (g group) Apply(log *slog.Logger, c container) error {
+func (g group) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
 	for _, cell := range g {
-		if err := cell.Apply(log, c); err != nil {
+		if err := cell.Apply(log, c, logThreshold); err != nil {
 			return err
 		}
 	}

--- a/cell/lifecycle.go
+++ b/cell/lifecycle.go
@@ -66,6 +66,8 @@ type DefaultLifecycle struct {
 	mu         sync.Mutex
 	hooks      []augmentedHook
 	numStarted int
+
+	LogThreshold time.Duration
 }
 
 type augmentedHook struct {
@@ -107,7 +109,11 @@ func (lc *DefaultLifecycle) Start(log *slog.Logger, ctx context.Context) error {
 			return err
 		}
 		d := time.Since(t0)
-		l.Info("Start hook executed", "duration", d)
+		if d > lc.LogThreshold {
+			l.Info("Start hook executed", "duration", d)
+		} else {
+			l.Debug("Start hook executed", "duration", d)
+		}
 		lc.numStarted++
 	}
 	return nil
@@ -142,7 +148,11 @@ func (lc *DefaultLifecycle) Stop(log *slog.Logger, ctx context.Context) error {
 			errs = errors.Join(errs, err)
 		} else {
 			d := time.Since(t0)
-			l.Info("Stop hook executed", "duration", d)
+			if d > lc.LogThreshold {
+				l.Info("Stop hook executed", "duration", d)
+			} else {
+				l.Debug("Stop hook executed", "duration", d)
+			}
 		}
 	}
 	return errs

--- a/cell/module.go
+++ b/cell/module.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"go.uber.org/dig"
 )
@@ -162,7 +163,7 @@ func (m *module) modulePrivateProviders(scope *dig.Scope) error {
 	return scope.Invoke(provide)
 }
 
-func (m *module) Apply(log *slog.Logger, c container) error {
+func (m *module) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
 	scope := c.Scope(m.id)
 
 	// Provide ModuleID and FullModuleID in the module's scope.
@@ -190,7 +191,7 @@ func (m *module) Apply(log *slog.Logger, c container) error {
 	}
 
 	for _, cell := range m.cells {
-		if err := cell.Apply(log, scope); err != nil {
+		if err := cell.Apply(log, scope, logThreshold); err != nil {
 			return err
 		}
 	}

--- a/cell/provide.go
+++ b/cell/provide.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/dig"
 
@@ -23,7 +24,7 @@ type provider struct {
 	export  bool
 }
 
-func (p *provider) Apply(log *slog.Logger, c container) error {
+func (p *provider) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
 	// Since the same Provide cell may be used multiple times
 	// in different hives we use a mutex to protect it and we
 	// fill the provide info only the first time.


### PR DESCRIPTION
Users of the library may not be interested to see a trace of every action
that the hive runs, but rather only log actions that take longer than a
specific threshold. Add an option that reduces the logging verbosity
based on how long the actions take.

Corresponds to https://github.com/cilium/cilium/pull/32033
