### PR TITLE
hive: take Logger as part of Start/Stop or Run

### DIFF
--- a/cell/cell.go
+++ b/cell/cell.go
@@ -4,9 +4,6 @@
 package cell
 
 import (
-	"log/slog"
-	"time"
-
 	"go.uber.org/dig"
 )
 
@@ -24,7 +21,7 @@ type Cell interface {
 	Info(container) Info
 
 	// Apply the cell to the dependency graph container.
-	Apply(*slog.Logger, container, time.Duration) error
+	Apply(container) error
 }
 
 // In when embedded into a struct used as constructor parameter makes the exported

--- a/cell/config.go
+++ b/cell/config.go
@@ -5,10 +5,8 @@ package cell
 
 import (
 	"fmt"
-	"log/slog"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/cilium/hive/internal"
 	"github.com/mitchellh/mapstructure"
@@ -146,7 +144,7 @@ func decoderConfig(target any, extraHooks DecodeHooks) *mapstructure.DecoderConf
 	}
 }
 
-func (c *config[Cfg]) Apply(log *slog.Logger, cont container, logThreshold time.Duration) error {
+func (c *config[Cfg]) Apply(cont container) error {
 	// Register the flags to the global set of all flags.
 	err := cont.Invoke(
 		func(allFlags *pflag.FlagSet) {

--- a/cell/decorator.go
+++ b/cell/decorator.go
@@ -5,8 +5,6 @@ package cell
 
 import (
 	"fmt"
-	"log/slog"
-	"time"
 
 	"github.com/cilium/hive/internal"
 )
@@ -40,14 +38,14 @@ type decorator struct {
 	cells     []Cell
 }
 
-func (d *decorator) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
+func (d *decorator) Apply(c container) error {
 	scope := c.Scope(fmt.Sprintf("(decorate %s)", internal.PrettyType(d.decorator)))
 	if err := scope.Decorate(d.decorator); err != nil {
 		return err
 	}
 
 	for _, cell := range d.cells {
-		if err := cell.Apply(log, scope, logThreshold); err != nil {
+		if err := cell.Apply(scope); err != nil {
 			return err
 		}
 	}

--- a/cell/group.go
+++ b/cell/group.go
@@ -3,11 +3,6 @@
 
 package cell
 
-import (
-	"log/slog"
-	"time"
-)
-
 type group []Cell
 
 // Group a set of cells. Unlike Module(), Group() does not create a new
@@ -16,9 +11,9 @@ func Group(cells ...Cell) Cell {
 	return group(cells)
 }
 
-func (g group) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
+func (g group) Apply(c container) error {
 	for _, cell := range g {
-		if err := cell.Apply(log, c, logThreshold); err != nil {
+		if err := cell.Apply(c); err != nil {
 			return err
 		}
 	}

--- a/cell/invoke.go
+++ b/cell/invoke.go
@@ -29,7 +29,7 @@ type namedFunc struct {
 }
 
 type InvokerList interface {
-	AppendInvoke(func() error)
+	AppendInvoke(func(*slog.Logger, time.Duration) error)
 }
 
 func (inv *invoker) invoke(log *slog.Logger, cont container, logThreshold time.Duration) error {
@@ -62,9 +62,9 @@ func (inv *invoker) invoke(log *slog.Logger, cont container, logThreshold time.D
 	return nil
 }
 
-func (inv *invoker) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
+func (inv *invoker) Apply(c container) error {
 	// Remember the scope in which we need to invoke.
-	invoker := func() error { return inv.invoke(log, c, logThreshold) }
+	invoker := func(log *slog.Logger, logThreshold time.Duration) error { return inv.invoke(log, c, logThreshold) }
 
 	// Append the invoker to the list of invoke functions. These are invoked
 	// prior to start to build up the objects. They are not invoked directly

--- a/cell/module.go
+++ b/cell/module.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"go.uber.org/dig"
 )
@@ -163,7 +162,7 @@ func (m *module) modulePrivateProviders(scope *dig.Scope) error {
 	return scope.Invoke(provide)
 }
 
-func (m *module) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
+func (m *module) Apply(c container) error {
 	scope := c.Scope(m.id)
 
 	// Provide ModuleID and FullModuleID in the module's scope.
@@ -191,7 +190,7 @@ func (m *module) Apply(log *slog.Logger, c container, logThreshold time.Duration
 	}
 
 	for _, cell := range m.cells {
-		if err := cell.Apply(log, scope, logThreshold); err != nil {
+		if err := cell.Apply(scope); err != nil {
 			return err
 		}
 	}

--- a/cell/provide.go
+++ b/cell/provide.go
@@ -5,11 +5,9 @@ package cell
 
 import (
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"go.uber.org/dig"
 
@@ -24,7 +22,7 @@ type provider struct {
 	export  bool
 }
 
-func (p *provider) Apply(log *slog.Logger, c container, logThreshold time.Duration) error {
+func (p *provider) Apply(c container) error {
 	// Since the same Provide cell may be used multiple times
 	// in different hives we use a mutex to protect it and we
 	// fill the provide info only the first time.

--- a/example/main.go
+++ b/example/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"log/slog"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/hive"
@@ -53,7 +55,7 @@ var (
 			// and then constructs all objects, followed by executing the start
 			// hooks in dependency order. It will then block waiting for signals
 			// after which it will run the stop hooks in reverse order.
-			if err := Hive.Run(); err != nil {
+			if err := Hive.Run(slog.Default()); err != nil {
 				// Run() can fail if:
 				// - There are missing types in the object graph
 				// - Executing the lifecycle start or stop hooks fails

--- a/hivetest/slog.go
+++ b/hivetest/slog.go
@@ -1,0 +1,86 @@
+package hivetest
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"slices"
+	"testing"
+)
+
+// Logger returns a logger which forwards structured logs to t.
+func Logger(t testing.TB, opts ...LogOption) *slog.Logger {
+	th := &testHandler{
+		t: t,
+	}
+	for _, o := range opts {
+		o(th)
+	}
+	return slog.New(th)
+}
+
+type LogOption func(*testHandler)
+
+func LogLevel(l slog.Level) LogOption {
+	return func(th *testHandler) {
+		th.level = l
+	}
+}
+
+// Will be accessed by multiple goroutines - needs to appear immutable.
+type testHandler struct {
+	t      testing.TB
+	level  slog.Level
+	fields []groupOrAttr
+}
+
+type groupOrAttr struct {
+	group string
+	attrs []slog.Attr
+}
+
+func (th *testHandler) Handle(ctx context.Context, r slog.Record) error {
+	// This doesn't do the right thing (as we're called from slog), but the API
+	// doesn't allow us to skip more callframes.
+	th.t.Helper()
+
+	// This is pretty inefficient if the handler has accumulated a lot of
+	// context, but necessary to make it trivially thread-safe. If it becomes
+	// necessary, we can always cache the handler we create here.
+	var buf bytes.Buffer
+	var h slog.Handler
+	h = slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		AddSource: true,
+	})
+	for _, ga := range th.fields {
+		if ga.group != "" {
+			h = h.WithGroup(ga.group)
+		} else {
+			h = h.WithAttrs(ga.attrs)
+		}
+	}
+	if err := h.Handle(ctx, r); err != nil {
+		return err
+	}
+
+	// Chomp the newline.
+	th.t.Log(string(buf.Bytes()[:buf.Len()-1]))
+
+	return nil
+}
+
+func (th *testHandler) WithGroup(g string) slog.Handler {
+	nt := *th
+	nt.fields = append(slices.Clone(th.fields), groupOrAttr{group: g})
+	return &nt
+}
+
+func (th *testHandler) WithAttrs(as []slog.Attr) slog.Handler {
+	nt := *th
+	nt.fields = append(slices.Clone(th.fields), groupOrAttr{attrs: as})
+	return &nt
+}
+
+func (th *testHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return th.level <= l
+}

--- a/job/observer_test.go
+++ b/job/observer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/stream"
 )
 
@@ -35,14 +36,15 @@ func TestObserver_ShortStream(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	// Continue as soon as all jobs stopped
 	g.(*group).wg.Wait()
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,11 +78,12 @@ func TestObserver_LongStream(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,13 +118,14 @@ func TestObserver_CtxClose(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	<-started
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/job/timer_test.go
+++ b/job/timer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 )
 
 // This test ensures that the timer function is called repeatedly.
@@ -38,13 +39,14 @@ func TestTimer_OnInterval(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	<-stop
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -75,7 +77,8 @@ func TestTimer_Trigger(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -88,7 +91,7 @@ func TestTimer_Trigger(t *testing.T) {
 	trigger.Trigger()
 	<-ran
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -132,13 +135,14 @@ func TestTimer_DoubleTrigger(t *testing.T) {
 	trigger.Trigger()
 	trigger.Trigger()
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	<-ran
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -165,11 +169,12 @@ func TestTimer_ExitOnClose(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,13 +207,14 @@ func TestTimer_ExitOnCloseFnCtx(t *testing.T) {
 		l.Append(g)
 	})
 
-	if err := h.Start(context.Background()); err != nil {
+	log := hivetest.Logger(t)
+	if err := h.Start(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
 	<-started
 
-	if err := h.Stop(context.Background()); err != nil {
+	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Instead of having to provide a logger already at hive creation time, pass the logger to Start/Stop/Run, which is when the underlying cells actually need it.

Also revert the changes to the Apply interface by passing the logger when the invokes are actually run instead of during apply.

Finally, add hivetest.Logger to create a logger from a testing.TB, so that the logs can be attributed to the correct test when running tests in parallel. Unfortunately, t.Helper() doesn't correctly work in combination with slog - we log the real source location as an attribute as a workaround.