### PR TITLE
job: Add debouncing trigger

### DIFF
--- a/job/metrics.go
+++ b/job/metrics.go
@@ -6,6 +6,7 @@ type Metrics interface {
 	JobError(name string, err error)
 	OneShotRunDuration(name string, duration time.Duration)
 	TimerRunDuration(name string, duration time.Duration)
+	TimerTriggerStats(name string, latency time.Duration, folds int)
 	ObserverRunDuration(name string, duration time.Duration)
 }
 
@@ -25,6 +26,10 @@ func (NopMetrics) OneShotRunDuration(name string, duration time.Duration) {
 
 // TimerRunDuration implements Metrics.
 func (NopMetrics) TimerRunDuration(name string, duration time.Duration) {
+}
+
+// TimerTriggerStats implements Metrics.
+func (NopMetrics) TimerTriggerStats(name string, latency time.Duration, folds int) {
 }
 
 var _ Metrics = NopMetrics{}


### PR DESCRIPTION
The current Trigger implementation does not allow folding multiple requests over a time interval. In the cilium codebase, this feature is available in the "github.com/cilium/cilium/pkg/trigger" package (see https://github.com/cilium/cilium/pull/32973#discussion_r1633050869 as an example) but lacks the benefits of the hive integration.

The PR adds the ability to specify a debounce interval to a timer trigger. Doing so, multiple trigger requests over the debounce interval are folded and the trigger is called just once. A debouncing trigger can work with:

- a timer with a zero interval: in this case the job runs only when explicitly requested, through a call to its trigger
- a timer with a non-zero interval: in this case the job runs also when the internal timer ticks, and the trigger is updated to account for this run

The job metrics interface is extended to make the trigger statistics available to the consumers. Right now, the trigger exports the latency between the first trigger and the actual job run, alongside the number of folded triggers in a debounce interval.

**Notes about alternative implementations**

1) a new job type to implement the debouncing trigger behavior

What I dislike about this approach is the possible confusion around the already existent `WithTrigger` option for the timer job and the new trigger job. This could have been avoided removing the trigger option for the timer, but apart from breaking the package public interface with a non backward compatible change, it would have removed a nice feature of the Timer job.

Overall, the changes needed to implement the new semantic seem not too difficult and consistent, so I think extending the timer is better.