### PR TITLE
job: Validate job.OneShot name

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -5,7 +5,9 @@ package job
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"regexp"
 	"runtime/pprof"
 	"sync"
 
@@ -228,4 +230,13 @@ type scopedGroup struct {
 
 func (sg *scopedGroup) Add(jobs ...Job) {
 	sg.group.add(sg.health, jobs...)
+}
+
+var nameRegex = regexp.MustCompile(`^[a-z][a-z0-9_\-]{0,30}$`)
+
+func validateName(name string) error {
+	if !nameRegex.MatchString(name) {
+		return fmt.Errorf("invalid job name: %q, expected to match %q", name, nameRegex)
+	}
+	return nil
 }

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -156,3 +156,32 @@ func TestModuleDecoratedGroup(t *testing.T) {
 	assert.NoError(t, h.Stop(log, context.Background()))
 	assert.Equal(t, 2, callCount, "expected OneShot function to be called twice")
 }
+
+func TestOneShot_ValidateName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		jbName      string
+		expectError bool
+	}{
+		{
+			name:        "valid",
+			jbName:      "valid_name",
+			expectError: false,
+		},
+		{
+			name:        "invalid name",
+			jbName:      "$%^&",
+			expectError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateName(tc.jbName)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/job/observer.go
+++ b/job/observer.go
@@ -16,10 +16,13 @@ import (
 	"github.com/cilium/stream"
 )
 
-// AddObserver adds an observer job to the group. Observer jobs invoke the given `fn` for each item observed on
-// `observable`. If the `observable` completes, the job stops. The context given to the observable is also canceled
-// once the group stops.
+// Observer jobs invoke the given `fn` for each item observed on `observable`.
+// The Observer name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". If the `observable` completes, the job stops.
+// The context given to the observable is also canceled once the group stops.
 func Observer[T any](name string, fn ObserverFunc[T], observable stream.Observable[T], opts ...observerOpt[T]) Job {
+	if err := validateName(name); err != nil {
+		panic(err)
+	}
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}

--- a/job/oneshot.go
+++ b/job/oneshot.go
@@ -14,14 +14,18 @@ import (
 	"github.com/cilium/hive/internal"
 )
 
-// OneShot creates a "one shot" job which can be added to a Group. The function passed to a one shot job is invoked
-// once at startup. It can live for the entire lifetime of the group or exit early depending on its task.
+// OneShot creates a "one shot" job which can be added to a Group.
+// The OneShot job name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". The function passed is invoked once at startup.
+// It can live for the entire lifetime of the group or exit early depending on its task.
 // If it returns an error, it can optionally be retried if the WithRetry option. If retries are not configured or
 // all retries failed as well, a shutdown of the hive can be triggered by specifying the WithShutdown option.
 //
 // The given function is expected to exit as soon as the context given to it expires, this is especially important for
 // blocking or long running jobs.
 func OneShot(name string, fn OneShotFunc, opts ...jobOneShotOpt) Job {
+	if err := validateName(name); err != nil {
+		panic(err)
+	}
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}

--- a/job/timer.go
+++ b/job/timer.go
@@ -14,8 +14,9 @@ import (
 	"github.com/cilium/hive/internal"
 )
 
-// Timer creates a timer job which can be added to a Group. Timer jobs invoke the given function at the specified
-// interval. Timer jobs are particularly useful to implement periodic syncs and cleanup actions.
+// Timer creates a timer job which can be added to a Group.
+// The Timer job name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". The function passed is invoked at the specified interval.
+// Timer jobs are particularly useful to implement periodic syncs and cleanup actions.
 // Timer jobs can optionally be triggered by an external Trigger with the WithTrigger option.
 // This trigger can for example be passed between cells or between jobs in the same cell to allow for an additional
 // invocation of the function.
@@ -25,6 +26,9 @@ import (
 // expires. This is especially important for long running functions. The signal created by a Trigger is coalesced so
 // multiple calls to trigger before the invocation takes place can result in just a single invocation.
 func Timer(name string, fn TimerFunc, interval time.Duration, opts ...timerOpt) Job {
+	if err := validateName(name); err != nil {
+		panic(err)
+	}
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}


### PR DESCRIPTION
Adds validation for job.OneShot to match regex `^[a-z][a-z0-9_\-]{0,30}$`. It avoids construction of jobs that are not usable for metrics.