### PR TITLE
Use DeferAcyclicVerification()

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -125,7 +125,7 @@ func New(cells ...cell.Cell) *Hive {
 func NewWithOptions(opts Options, cells ...cell.Cell) *Hive {
 	h := &Hive{
 		opts:      opts,
-		container: dig.New(),
+		container: dig.New(dig.DeferAcyclicVerification()),
 		cells:     cells,
 		viper:     viper.New(),
 		flags:     pflag.NewFlagSet("", pflag.ContinueOnError),


### PR DESCRIPTION
uber/dig defaults to checking for cycles on each Provide() call, which on large graphs becomes pretty expensive (cilium-agent is getting into multiple seconds now). To speed things up, set the DeferAcyclicVerification option on the dig container (cycles are checked on each Invoke).

Here's the effect on TestAgentCells in cilium/cilium:

Before:
```
  daemon/cmd$ go test . -test.run TestAgentCell -test.count 1
  ok      github.com/cilium/cilium/daemon/cmd     3.674s
```

After:
```
  daemon/cmd$ go test . -test.run TestAgentCell -test.count 1
  ok      github.com/cilium/cilium/daemon/cmd     0.192s
```