### PR TITLE
Bump max job name length

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -232,7 +232,7 @@ func (sg *scopedGroup) Add(jobs ...Job) {
 	sg.group.add(sg.health, jobs...)
 }
 
-var nameRegex = regexp.MustCompile(`^[a-z][a-z0-9_\-]{0,30}$`)
+var nameRegex = regexp.MustCompile(`^[a-z][a-z0-9_\-]{0,100}$`)
 
 func validateName(name string) error {
 	if !nameRegex.MatchString(name) {

--- a/job/observer.go
+++ b/job/observer.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Observer jobs invoke the given `fn` for each item observed on `observable`.
-// The Observer name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". If the `observable` completes, the job stops.
+// The Observer name must match regex "^[a-z][a-z0-9_\\-]{0,100}$". If the `observable` completes, the job stops.
 // The context given to the observable is also canceled once the group stops.
 func Observer[T any](name string, fn ObserverFunc[T], observable stream.Observable[T], opts ...observerOpt[T]) Job {
 	if err := validateName(name); err != nil {

--- a/job/oneshot.go
+++ b/job/oneshot.go
@@ -15,7 +15,7 @@ import (
 )
 
 // OneShot creates a "one shot" job which can be added to a Group.
-// The OneShot job name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". The function passed is invoked once at startup.
+// The OneShot job name must match regex "^[a-z][a-z0-9_\\-]{0,100}$". The function passed is invoked once at startup.
 // It can live for the entire lifetime of the group or exit early depending on its task.
 // If it returns an error, it can optionally be retried if the WithRetry option. If retries are not configured or
 // all retries failed as well, a shutdown of the hive can be triggered by specifying the WithShutdown option.

--- a/job/timer.go
+++ b/job/timer.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Timer creates a timer job which can be added to a Group.
-// The Timer job name must match regex "^[a-z][a-z0-9_\\-]{0,30}$". The function passed is invoked at the specified interval.
+// The Timer job name must match regex "^[a-z][a-z0-9_\\-]{0,100}$". The function passed is invoked at the specified interval.
 // Timer jobs are particularly useful to implement periodic syncs and cleanup actions.
 // Timer jobs can optionally be triggered by an external Trigger with the WithTrigger option.
 // This trigger can for example be passed between cells or between jobs in the same cell to allow for an additional


### PR DESCRIPTION
Increasing the job name length from 30 characters to 100 to accommodate lon names for jobs. This includes the StateDB Reflectors, the job names for that have a table name of 30 characters and also the job name and the prefix.