### PR TITLE
job: Sanitize instead of validate the job names

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -5,9 +5,9 @@ package job
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"runtime/pprof"
 	"sync"
 
@@ -232,11 +232,34 @@ func (sg *scopedGroup) Add(jobs ...Job) {
 	sg.group.add(sg.health, jobs...)
 }
 
-var nameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_\-]{0,100}$`)
+const maxNameLength = 100
 
-func validateName(name string) error {
-	if !nameRegex.MatchString(name) {
-		return fmt.Errorf("invalid job name: %q, expected to match %q", name, nameRegex)
+func sanitizeName(name string) string {
+	mangled := false
+	newLength := min(maxNameLength, len(name))
+	runes := make([]rune, 0, newLength)
+	for _, r := range name[:newLength] {
+		switch {
+		case r >= 'a' && r <= 'z':
+			fallthrough
+		case r >= 'A' && r <= 'Z':
+			fallthrough
+		case r >= '0' && r <= '9':
+			fallthrough
+		case r == '-' || r == '_':
+			runes = append(runes, r)
+		default:
+			// Skip invalid characters.
+			mangled = true
+		}
 	}
-	return nil
+	if mangled || len(name) > maxNameLength {
+		// Name was mangled or is too long, truncate and append hash.
+		const hashLen = 10
+		hash := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+		newLen := min(maxNameLength-hashLen, len(runes))
+		runes = runes[:newLen]
+		return string(runes) + "-" + hash[:hashLen]
+	}
+	return string(runes)
 }

--- a/job/observer.go
+++ b/job/observer.go
@@ -20,9 +20,7 @@ import (
 // The Observer name must match regex "^[a-zA-Z][a-zA-Z0-9_\-]{0,100}$". If the `observable` completes, the job stops.
 // The context given to the observable is also canceled once the group stops.
 func Observer[T any](name string, fn ObserverFunc[T], observable stream.Observable[T], opts ...observerOpt[T]) Job {
-	if err := validateName(name); err != nil {
-		panic(err)
-	}
+	name = sanitizeName(name)
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}

--- a/job/oneshot.go
+++ b/job/oneshot.go
@@ -23,9 +23,7 @@ import (
 // The given function is expected to exit as soon as the context given to it expires, this is especially important for
 // blocking or long running jobs.
 func OneShot(name string, fn OneShotFunc, opts ...jobOneShotOpt) Job {
-	if err := validateName(name); err != nil {
-		panic(err)
-	}
+	name = sanitizeName(name)
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}

--- a/job/timer.go
+++ b/job/timer.go
@@ -26,9 +26,7 @@ import (
 // expires. This is especially important for long running functions. The signal created by a Trigger is coalesced so
 // multiple calls to trigger before the invocation takes place can result in just a single invocation.
 func Timer(name string, fn TimerFunc, interval time.Duration, opts ...timerOpt) Job {
-	if err := validateName(name); err != nil {
-		panic(err)
-	}
+	name = sanitizeName(name)
 	if fn == nil {
 		panic("`fn` must not be nil")
 	}


### PR DESCRIPTION
The job names may come from many different sources and it is too much of a foot-gun to reject the names by panicing.

Instead to keep the names within a nice constraint set of characters and length, sanitize the names silently.

Related PR that had to work around the panics:
https://github.com/cilium/cilium/pull/35031