### PR TITLE
script: Add support for interrupts

### DIFF
--- a/script/README.md
+++ b/script/README.md
@@ -1,2 +1,4 @@
 This is a fork of rsc.io/script (v0.0.2). It mostly adds support for interactive use to it.
 
+The makeraw* files are adapted from term_unix.go etc. files from x/term to enable interrupts.
+

--- a/script/cmds.go
+++ b/script/cmds.go
@@ -1149,7 +1149,7 @@ func Break() Cmd {
 			engine := s.engine
 
 			term := term.NewTerminal(tty, "debug> ")
-			s.flushLog(term)
+			s.FlushLog()
 			fmt.Fprintf(term, "\nBreak! Control-d to continue.\n")
 
 			for {

--- a/script/makeraw_unix.go
+++ b/script/makeraw_unix.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd || aix || linux || solaris || zos
+
+package script
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// MakeRaw sets the terminal to raw mode, but with interrupt signals enabled.
+func MakeRaw(fd int) (restore func(), err error) {
+	termios, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, err
+	}
+
+	oldState := *termios
+
+	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	termios.Oflag &^= unix.OPOST
+	termios.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.IEXTEN
+	termios.Lflag |= unix.ISIG // Enable interrupt signals
+	termios.Cflag &^= unix.CSIZE | unix.PARENB
+	termios.Cflag |= unix.CS8
+	termios.Cc[unix.VMIN] = 1
+	termios.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, termios); err != nil {
+		return nil, err
+	}
+
+	return func() {
+		unix.IoctlSetTermios(fd, ioctlWriteTermios, &oldState)
+	}, nil
+}

--- a/script/makeraw_unix_bsd.go
+++ b/script/makeraw_unix_bsd.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package script
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+const (
+	ioctlReadTermios  = unix.TIOCGETA
+	ioctlWriteTermios = unix.TIOCSETA
+)

--- a/script/makeraw_unix_other.go
+++ b/script/makeraw_unix_other.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || linux || solaris || zos
+
+package script
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlReadTermios  = unix.TCGETS
+	ioctlWriteTermios = unix.TCSETS
+)

--- a/script/makeraw_unsupported.go
+++ b/script/makeraw_unsupported.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !darwin && !linux
+
+package script
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func MakeRaw(fd int) (restore func(), err error) {
+	return func() {}, fmt.Errorf("MakeRaw: not supported on %s", runtime.GOOS)
+}


### PR DESCRIPTION
This adds the ability to interrupt long-running commands. This is needed to implement something like "db watch table" that watches a table for changes until interrupted with ctrl-c.

See commits for more details.

You can try this out with:
```
go run ./example repl
> hive start
> events
```