### PR TITLE
job: Close the health reporter instead of stopping

### DIFF
--- a/job/observer.go
+++ b/job/observer.go
@@ -62,6 +62,8 @@ func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, health 
 	}
 
 	jo.health = health.NewScope("observer-job-" + jo.name)
+	defer jo.health.Close()
+
 	reportTicker := time.NewTicker(10 * time.Second)
 	defer reportTicker.Stop()
 
@@ -121,7 +123,6 @@ func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, health 
 
 	<-done
 
-	jo.health.Stopped("observer job done")
 	if err != nil {
 		l.Error("Observer job stopped with an error", "error", err)
 	} else {

--- a/job/oneshot.go
+++ b/job/oneshot.go
@@ -110,7 +110,7 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, health cel
 	}
 
 	jos.health = health.NewScope("job-" + jos.name)
-	defer jos.health.Stopped("one-shot job done")
+	defer jos.health.Close()
 
 	l := options.logger.With(
 		"name", jos.name,

--- a/job/timer.go
+++ b/job/timer.go
@@ -152,6 +152,7 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, health cell.H
 	}
 
 	jt.health = health.NewScope("timer-job-" + jt.name)
+	defer jt.health.Close()
 
 	l := options.logger.With(
 		"name", jt.name,
@@ -175,7 +176,6 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, health cell.H
 	for {
 		select {
 		case <-ctx.Done():
-			jt.health.Stopped("timer job context done")
 			return
 		case <-tickerChan:
 		case <-triggerChan:


### PR DESCRIPTION
When timer/one-shot/observer job finishes it should close the health reporting instead of stopping it in order not to accumulate endless number of health statuses for one-off etc. jobs.