### PR TITLE
scripttest: Pass testing.TB to newEngine

### DIFF
--- a/script/scripttest/scripttest.go
+++ b/script/scripttest/scripttest.go
@@ -150,7 +150,7 @@ func CachedExec() script.Cond {
 		})
 }
 
-func Test(t *testing.T, ctx context.Context, newEngine func() *script.Engine, env []string, pattern string) {
+func Test(t *testing.T, ctx context.Context, newEngine func(testing.TB) *script.Engine, env []string, pattern string) {
 	gracePeriod := 100 * time.Millisecond
 	if deadline, ok := t.Deadline(); ok {
 		timeout := time.Until(deadline)
@@ -209,7 +209,7 @@ func Test(t *testing.T, ctx context.Context, newEngine func() *script.Engine, en
 			// editors that can jump to file:line references in the output
 			// will work better seeing the full path relative to cmd/go
 			// (where the "go test" command is usually run).
-			Run(t, newEngine(), s, file, bytes.NewReader(a.Comment))
+			Run(t, newEngine(t), s, file, bytes.NewReader(a.Comment))
 		})
 	}
 }

--- a/script/scripttest/scripttest_test.go
+++ b/script/scripttest/scripttest_test.go
@@ -21,5 +21,5 @@ func TestAll(t *testing.T) {
 		Quiet: !testing.Verbose(),
 	}
 	env := os.Environ()
-	scripttest.Test(t, ctx, func() *script.Engine { return engine }, env, "testdata/*.txt")
+	scripttest.Test(t, ctx, func(t testing.TB) *script.Engine { return engine }, env, "testdata/*.txt")
 }


### PR DESCRIPTION
To allow cleaning up resources after the test terminates, pass the testing.TB to the newEngine function.

This is needed to be able to stop the hive in a test:
```
  scripttest.Test(...,
    func(t testing.TB) *script.Engine {
      h := hive.New(Thing)
      require.NoError(t, h.Start(...))
      t.Cleanup(func() {
       assert.NoError(t, h.Stop(...))
      })
      return &script.Engine{...}
    }, ...)
```