### PR TITLE
script: Add '*' and '!*' prefixes for retrying commands and -scripttest.update for updating files

### DIFF
--- a/script/cmds.go
+++ b/script/cmds.go
@@ -249,6 +249,14 @@ func doCompare(s *State, env bool, args ...string) error {
 	}
 
 	if text1 != text2 {
+		if s.DoUpdate {
+			// Updates requested, store the file contents and
+			// ignore mismatches.
+			s.FileUpdates[name1] = text2
+			s.FileUpdates[name2] = text1
+			return nil
+		}
+
 		if !quiet {
 			diffText := diff.Diff(name1, []byte(text1), name2, []byte(text2))
 			s.Logf("%s\n", diffText)
@@ -653,7 +661,7 @@ func match(s *State, args []string, text, name string) error {
 	isGrep := name == "grep"
 
 	wantArgs := 1
-	if len(args) != wantArgs {
+	if !isGrep && len(args) != wantArgs {
 		return ErrUsage
 	}
 

--- a/script/scripttest/scripttest.go
+++ b/script/scripttest/scripttest.go
@@ -154,7 +154,7 @@ func CachedExec() script.Cond {
 		})
 }
 
-func Test(t *testing.T, ctx context.Context, newEngine func(testing.TB) *script.Engine, env []string, pattern string) {
+func Test(t *testing.T, ctx context.Context, newEngine func(tb testing.TB, args []string) *script.Engine, env []string, pattern string) {
 	gracePeriod := 100 * time.Millisecond
 	if deadline, ok := t.Deadline(); ok {
 		timeout := time.Until(deadline)
@@ -203,6 +203,17 @@ func Test(t *testing.T, ctx context.Context, newEngine func(testing.TB) *script.
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Extract args from a shebang line, e.g.:
+			// #! -foo=1 -bar=true
+			// => ["-foo=1", "-bar=true"]
+			var args []string
+			if shebang, found := strings.CutPrefix(string(a.Comment), "#!"); found {
+				shebang, _, _ = strings.Cut(shebang, "\n")
+				shebang = strings.TrimSpace(shebang)
+				args = strings.Split(shebang, " ")
+			}
+
 			initScriptDirs(t, s)
 			if err := s.ExtractFiles(a); err != nil {
 				t.Fatal(err)
@@ -216,7 +227,7 @@ func Test(t *testing.T, ctx context.Context, newEngine func(testing.TB) *script.
 			// editors that can jump to file:line references in the output
 			// will work better seeing the full path relative to cmd/go
 			// (where the "go test" command is usually run).
-			Run(t, newEngine(t), s, file, bytes.NewReader(a.Comment))
+			Run(t, newEngine(t, args), s, file, bytes.NewReader(a.Comment))
 
 			if *updateFlag {
 				updated := false

--- a/script/scripttest/scripttest_test.go
+++ b/script/scripttest/scripttest_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/script"
 	"github.com/cilium/hive/script/scripttest"
@@ -16,9 +17,10 @@ import (
 func TestAll(t *testing.T) {
 	ctx := context.Background()
 	engine := &script.Engine{
-		Conds: scripttest.DefaultConds(),
-		Cmds:  scripttest.DefaultCmds(),
-		Quiet: !testing.Verbose(),
+		Conds:         scripttest.DefaultConds(),
+		Cmds:          scripttest.DefaultCmds(),
+		Quiet:         !testing.Verbose(),
+		RetryInterval: 10 * time.Millisecond,
 	}
 	env := os.Environ()
 	scripttest.Test(t, ctx, func(t testing.TB) *script.Engine { return engine }, env, "testdata/*.txt")

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -2,5 +2,11 @@ cat hello.txt
 stdout 'hello world'
 ! stderr 'hello world'
 
+exec sh -c 'sleep 0.1 && echo > out.txt' &
+
+# Retry section test
+echo hello
+* exec cat out.txt
+
 -- hello.txt --
 hello world

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -2,11 +2,13 @@ cat hello.txt
 stdout 'hello world'
 ! stderr 'hello world'
 
-exec sh -c 'sleep 0.1 && echo > out.txt' &
+exec sh -c 'sleep 0.1 && echo world > out.txt' &
 
 # Retry section test
 echo hello
-* exec cat out.txt
+* cat out.txt
+* grep world out.txt
+!* grep blah out.txt
 
 -- hello.txt --
 hello world

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -1,3 +1,9 @@
+#! -foo=bar -baz=quux
+
+# Verify the shebang args parsing
+args
+grep '^-foo=bar:-baz=quux$'
+
 cat hello.txt
 stdout 'hello world'
 ! stderr 'hello world'
@@ -9,6 +15,8 @@ echo hello
 * cat out.txt
 * grep world out.txt
 !* grep blah out.txt
+
+wait
 
 -- hello.txt --
 hello world

--- a/script/state.go
+++ b/script/state.go
@@ -26,7 +26,6 @@ type State struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
-	file   string
 	log    bytes.Buffer
 	logOut io.Writer
 

--- a/script/state.go
+++ b/script/state.go
@@ -36,6 +36,9 @@ type State struct {
 	stdout  string            // standard output from last 'go' command; for 'stdout' command
 	stderr  string            // standard error from last 'go' command; for 'stderr' command
 
+	DoUpdate    bool
+	FileUpdates map[string]string
+
 	background []backgroundCmd
 }
 
@@ -78,12 +81,13 @@ func NewState(ctx context.Context, workdir string, initialEnv []string) (*State,
 	}
 
 	s := &State{
-		ctx:     ctx,
-		cancel:  cancel,
-		workdir: absWork,
-		pwd:     absWork,
-		env:     env,
-		envMap:  envMap,
+		ctx:         ctx,
+		cancel:      cancel,
+		workdir:     absWork,
+		pwd:         absWork,
+		env:         env,
+		envMap:      envMap,
+		FileUpdates: make(map[string]string),
 	}
 	s.Setenv("PWD", absWork)
 	return s, nil


### PR DESCRIPTION
script: Add '*' prefix for retrying commands

This adds a generic facility for retrying failing commands.

A command that is prefixed with '*' and fails will cause the whole section (delimited by '#' comments) to be retried from the top.

Retrying is repeated until the command succeeds or the context is cancelled. The retry interval can be set in (*Engine).RetryInterval.

Example usage:
```
  # Verify table contents
  db show -o=out.table my-table
  * cmp out.table expected.table
```

---

script: Add -scripttest.update to update txtar files

To make it easy to create and update expected test outputs, add the
-scripttest.update flag which updates the txtar files with the 'cmp'
inputs.

To allow waiting for the inputs to reach expected state, add the '!*'
prefix for retrying until failure, e.g. to allow writing:
```
  # Wait until no 'Pending' columns exist
  db show -columns=Status -o out.table test-table
  !* grep Pending out.table
  * cmp expected.table out.table
```

Now running "go test . -scripttest.update" will update the 'expected.table',
but only after it passes the grep.

---

scripttest: Add support for shebang args

Sometimes it's useful to change the test parameters from the script
itself.

To allow for that, add support for parsing the first line of the script
as arguments and pass those to the engine constructor. For example the
test script:
```
  #! -foo=bar -baz=1
  ...
```

will cause the engine constructor to be called with
[]string{"-foo=bar", "-baz=1"}. These can then be parsed as one wants,
though with the idea that they could be used to configure the hive:
```
  func myTestEngine(t testing.TB, args []string) *scripttest.Engine {
    h := hive.New(...)
    flags := pflag.NewFlagSet("", pflag.ContinueOnError)
    h.RegisterFlags(flags)
	flags.Parse(args)
	...
  }
```
