### PR TITLE
cell: Add DecorateAll for decorating everywhere

### DIFF
--- a/cell/cell.go
+++ b/cell/cell.go
@@ -21,7 +21,7 @@ type Cell interface {
 	Info(container) Info
 
 	// Apply the cell to the dependency graph container.
-	Apply(container) error
+	Apply(container, rootContainer) error
 }
 
 // In when embedded into a struct used as constructor parameter makes the exported
@@ -49,3 +49,5 @@ type container interface {
 	Decorate(fn any, opts ...dig.DecorateOption) error
 	Scope(name string, opts ...dig.ScopeOption) *dig.Scope
 }
+
+type rootContainer = container

--- a/cell/config.go
+++ b/cell/config.go
@@ -143,7 +143,7 @@ func decoderConfig(target any, extraHooks DecodeHooks) *mapstructure.DecoderConf
 	}
 }
 
-func (c *config[Cfg]) Apply(cont container) error {
+func (c *config[Cfg]) Apply(cont container, _ rootContainer) error {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	c.defaultConfig.Flags(flags)
 

--- a/cell/group.go
+++ b/cell/group.go
@@ -11,9 +11,9 @@ func Group(cells ...Cell) Cell {
 	return group(cells)
 }
 
-func (g group) Apply(c container) error {
+func (g group) Apply(c container, rc rootContainer) error {
 	for _, cell := range g {
-		if err := cell.Apply(c); err != nil {
+		if err := cell.Apply(c, rc); err != nil {
 			return err
 		}
 	}

--- a/cell/invoke.go
+++ b/cell/invoke.go
@@ -62,7 +62,7 @@ func (inv *invoker) invoke(log *slog.Logger, cont container, logThreshold time.D
 	return nil
 }
 
-func (inv *invoker) Apply(c container) error {
+func (inv *invoker) Apply(c container, _ rootContainer) error {
 	// Remember the scope in which we need to invoke.
 	invoker := func(log *slog.Logger, logThreshold time.Duration) error { return inv.invoke(log, c, logThreshold) }
 

--- a/cell/module.go
+++ b/cell/module.go
@@ -162,7 +162,7 @@ func (m *module) modulePrivateProviders(scope *dig.Scope) error {
 	return scope.Invoke(provide)
 }
 
-func (m *module) Apply(c container) error {
+func (m *module) Apply(c container, rc rootContainer) error {
 	scope := c.Scope(m.id)
 
 	// Provide ModuleID and FullModuleID in the module's scope.
@@ -190,7 +190,7 @@ func (m *module) Apply(c container) error {
 	}
 
 	for _, cell := range m.cells {
-		if err := cell.Apply(scope); err != nil {
+		if err := cell.Apply(scope, rc); err != nil {
 			return err
 		}
 	}

--- a/cell/provide.go
+++ b/cell/provide.go
@@ -22,7 +22,7 @@ type provider struct {
 	export  bool
 }
 
-func (p *provider) Apply(c container) error {
+func (p *provider) Apply(c container, rc rootContainer) error {
 	// Since the same Provide cell may be used multiple times
 	// in different hives we use a mutex to protect it and we
 	// fill the provide info only the first time.

--- a/hive.go
+++ b/hive.go
@@ -145,7 +145,7 @@ func NewWithOptions(opts Options, cells ...cell.Cell) *Hive {
 	// and adds all config flags. Invokes are delayed until Start() is
 	// called.
 	for _, cell := range cells {
-		if err := cell.Apply(h.container); err != nil {
+		if err := cell.Apply(h.container, h.container); err != nil {
 			panic(fmt.Sprintf("Failed to apply cell: %s", err))
 		}
 	}


### PR DESCRIPTION
Add the ability to decorate a type in all scopes. This is sometimes useful when one needs to swap out a value or implementation coming from a cell that one doesn't control.