### PR TITLE
script: Revert buggy change to grep command

### DIFF
--- a/script/cmds.go
+++ b/script/cmds.go
@@ -661,7 +661,10 @@ func match(s *State, args []string, text, name string) error {
 	isGrep := name == "grep"
 
 	wantArgs := 1
-	if !isGrep && len(args) != wantArgs {
+	if isGrep {
+		wantArgs = 2
+	}
+	if len(args) != wantArgs {
 		return ErrUsage
 	}
 
@@ -672,16 +675,12 @@ func match(s *State, args []string, text, name string) error {
 	}
 
 	if isGrep {
-		if len(args) == 1 || args[1] == "-" {
-			text = s.stdout
-		} else {
-			name = args[1] // for error messages
-			data, err := os.ReadFile(s.Path(args[1]))
-			if err != nil {
-				return err
-			}
-			text = string(data)
+		name = args[1] // for error messages
+		data, err := os.ReadFile(s.Path(args[1]))
+		if err != nil {
+			return err
 		}
+		text = string(data)
 	}
 
 	if n > 0 {

--- a/script/engine.go
+++ b/script/engine.go
@@ -772,7 +772,15 @@ func (e *Engine) ListCmds(w io.Writer, verbose bool, regexMatch string) error {
 		if re != nil && !re.MatchString(name) {
 			continue
 		}
-		cmd := e.Cmds[name]
+		cmd, ok := e.Cmds[name]
+		if !ok {
+			_, err := fmt.Fprintf(w, "command %q is not registered\n", name)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
 		usage := cmd.Usage()
 
 		suffix := ""

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -1,5 +1,9 @@
 #! -foo=bar -baz=quux
 
+help
+help cat
+help unknown-command
+
 # Verify the shebang args parsing
 args
 stdout '^-foo=bar:-baz=quux$'
@@ -21,14 +25,14 @@ wait
 # Test help in various ways
 help
 help wait
-grep wait
+stdout wait
 help -v wait
-grep wait
+stdout wait
 help unknowncommand
 help ^e
-! grep wait
-grep ^exec
-grep ^exists
+! stdout wait
+stdout ^exec
+stdout ^exists
 
 -- hello.txt --
 hello world

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -2,7 +2,7 @@
 
 # Verify the shebang args parsing
 args
-grep '^-foo=bar:-baz=quux$'
+stdout '^-foo=bar:-baz=quux$'
 
 cat hello.txt
 stdout 'hello world'


### PR DESCRIPTION
The stdout and stderr commands already existed, and my change to grep to allow searching stdout was buggy, so revert this.

The second commit fixes a panic on "help some-unknown-command" (https://github.com/cilium/cilium/pull/35918)