### PR TITLE
[fix] skip empty command

### DIFF
--- a/script.go
+++ b/script.go
@@ -44,7 +44,9 @@ type ScriptCmds struct {
 func (sc ScriptCmds) Map() map[string]script.Cmd {
 	m := make(map[string]script.Cmd, len(sc.ScriptCmds))
 	for _, c := range sc.ScriptCmds {
-		m[c.Name] = c.Cmd
+		if c.Name != "" {
+			m[c.Name] = c.Cmd
+		}
 	}
 	return m
 }


### PR DESCRIPTION
When newBPFReconciler is not enabled, it return an empty ScriptCmd. Which cause `cilium shell help` panic.

https://github.com/cilium/cilium/blob/21ad13700b0f295e4997ffe4d204a9dbcd4cf309/pkg/loadbalancer/experimental/bpf_reconciler.go#L48-L51

```
PANIC: runtime error: invalid memory address or nil pointer dereference
goroutine 1947 [running]:
github.com/cilium/cilium/daemon/cmd.shell.handleConn.func2()
	/go/src/github.com/cilium/cilium/daemon/cmd/shell.go:117 +0x78
panic({0x36dd600?, 0x706ef80?})
	/usr/local/go/src/runtime/panic.go:785 +0x124
github.com/cilium/hive/script.(*Engine).ListCmds(0x40004f6b00, {0x4689a00, 0x400045ae00}, 0x0, {0x0?, 0x4c?, 0x4003a55768?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/engine.go:770 +0x104
github.com/cilium/hive/script.DefaultCmds.Help.func13(0x4002173340, {0x7675940?, 0x0, 0x732fec?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/cmds.go:760 +0x3c8
github.com/cilium/hive/script.(*funcCmd).Run(0x0?, 0x2aaaaaaaa?, {0x7675940?, 0x108888?, 0x394dca0?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/cmds.go:73 +0x38
github.com/cilium/hive/script.(*Engine).runCommand(0x4002173340?, 0x4002173340, 0x4003df6ab0, {0x46bd7f8, 0x4001e61860})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/engine.
```