### PR TITLE
Change hive startup message

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -72,7 +72,7 @@ var (
 	//
 	//   $ go run . repl
 	//   example> hive start
-	//   time=2024-10-08T09:39:00.881+02:00 level=INFO msg=Starting
+	//   time=2024-10-08T09:39:00.881+02:00 level=INFO msg=Starting hive
 	//   ...
 	//   example> events
 	//   ...

--- a/hive.go
+++ b/hive.go
@@ -335,7 +335,7 @@ func (h *Hive) Start(log *slog.Logger, ctx context.Context) error {
 
 	defer close(h.fatalOnTimeout(ctx))
 
-	log.Info("Starting")
+	log.Info("Starting hive")
 	start := time.Now()
 	err := h.lifecycle.Start(log, ctx)
 	if err == nil {


### PR DESCRIPTION
Currently, when starting the hive in cilium-agent we emit a log line:

    2024-11-28T15:29:27.262458836Z time=2024-11-28T15:29:27Z level=info msg=Starting

which isn't particularly useful. Change it to mention the hive, so its a bit more informative.