### PR TITLE
script: Fix crash when help called with unknown command

### DIFF
--- a/script/cmds.go
+++ b/script/cmds.go
@@ -716,11 +716,13 @@ func Help() Cmd {
 	return Command(
 		CmdUsage{
 			Summary: "log help text for commands and conditions",
-			Args:    "[-v] name...",
+			Args:    "[-v] (regexp)",
 			Detail: []string{
 				"To display help for a specific condition, enclose it in brackets: 'help [amd64]'.",
 				"To display complete documentation when listing all commands, pass the -v flag.",
+				"Commands can be filtered with a regexp: 'help ^db'",
 			},
+			RegexpArgs: firstNonFlag,
 		},
 		func(s *State, args ...string) (WaitFunc, error) {
 			if s.engine == nil {
@@ -757,7 +759,7 @@ func Help() Cmd {
 				if len(args) == 0 {
 					out.WriteString("\ncommands:\n\n")
 				}
-				s.engine.ListCmds(out, verbose, cmds...)
+				s.engine.ListCmds(out, verbose, strings.Join(cmds, " "))
 			}
 
 			wait := func(*State) (stdout, stderr string, err error) {

--- a/script/engine.go
+++ b/script/engine.go
@@ -58,6 +58,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -752,25 +753,26 @@ func checkStatus(cmd *command, err error) error {
 // ListCmds prints to w a list of the named commands,
 // annotating each with its arguments and a short usage summary.
 // If verbose is true, ListCmds prints full details for each command.
-//
-// Each of the name arguments should be a command name.
-// If no names are passed as arguments, ListCmds lists all the
-// commands registered in e.
-func (e *Engine) ListCmds(w io.Writer, verbose bool, names ...string) error {
-	if names == nil {
-		names = make([]string, 0, len(e.Cmds))
-		for name := range e.Cmds {
-			names = append(names, name)
+func (e *Engine) ListCmds(w io.Writer, verbose bool, regexMatch string) error {
+	var re *regexp.Regexp
+	if regexMatch != "" {
+		var err error
+		re, err = regexp.Compile(regexMatch)
+		if err != nil {
+			return err
 		}
-		sort.Strings(names)
 	}
+	names := make([]string, 0, len(e.Cmds))
+	for name := range e.Cmds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
 	for _, name := range names {
-		cmd, ok := e.Cmds[name]
-		if !ok {
-			fmt.Fprintf(w, "command %q not found\n", name)
+		if re != nil && !re.MatchString(name) {
 			continue
 		}
+		cmd := e.Cmds[name]
 		usage := cmd.Usage()
 
 		suffix := ""

--- a/script/engine.go
+++ b/script/engine.go
@@ -766,7 +766,11 @@ func (e *Engine) ListCmds(w io.Writer, verbose bool, names ...string) error {
 	}
 
 	for _, name := range names {
-		cmd := e.Cmds[name]
+		cmd, ok := e.Cmds[name]
+		if !ok {
+			fmt.Fprintf(w, "command %q not found\n", name)
+			continue
+		}
 		usage := cmd.Usage()
 
 		suffix := ""

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -18,5 +18,11 @@ echo hello
 
 wait
 
+# Test help in various ways
+help
+help wait
+help -v wait
+help unknowncommand
+
 -- hello.txt --
 hello world

--- a/script/scripttest/testdata/basic.txt
+++ b/script/scripttest/testdata/basic.txt
@@ -21,8 +21,14 @@ wait
 # Test help in various ways
 help
 help wait
+grep wait
 help -v wait
+grep wait
 help unknowncommand
+help ^e
+! grep wait
+grep ^exec
+grep ^exists
 
 -- hello.txt --
 hello world


### PR DESCRIPTION
'help some-unknown-command' crashed as ListCmds wasn't checking if the command was actually found from the commands map.

While at it, make the 'help' a bit more useful by allowing filtering of commands with a regexp.