### PR TITLE
script: Implement simple "sed" command

### DIFF
--- a/script/scripttest/testdata/sed.txt
+++ b/script/scripttest/testdata/sed.txt
@@ -1,0 +1,20 @@
+# Tests for the sed command
+
+sed '' '' input.txt
+sed notfound unexpected input.txt
+sed \d+ N input.txt
+sed [uz] '' input.txt
+sed a(x*)b 'a${1}c' input.txt
+sed ^(s+)$ '${1}${1}' input.txt
+cmp input.txt expected.txt
+
+-- input.txt --
+foo123bar
+quuxbaz123
+axxxxxxb
+sss
+-- expected.txt --
+fooNbar
+qxbaN
+axxxxxxc
+ssssss


### PR DESCRIPTION
The simple 'replace' command falls short in situations where the input text isn't fully known, but still needs to be sanitized in some way. Instead of having to use e.g. the system 'sed' command, implement a very simple built-in version.