### PR TITLE
cell: Fail hive configuration on duplicate flags

### DIFF
--- a/cell/config.go
+++ b/cell/config.go
@@ -4,6 +4,7 @@
 package cell
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/dig"
 )
+
+var ErrDuplicateFlag = errors.New("duplicate flag")
 
 // Config constructs a new config cell.
 //
@@ -149,8 +152,16 @@ func (c *config[Cfg]) Apply(cont container, _ rootContainer) error {
 
 	// Register the flags to the global set of all flags.
 	err := cont.Invoke(
-		func(allFlags *pflag.FlagSet) {
+		func(allFlags *pflag.FlagSet) error {
+			var err error
+			flags.VisitAll(func(flag *pflag.Flag) {
+				if allFlags.Lookup(flag.Name) != nil {
+					err2 := fmt.Errorf("'%s' declared twice: %w", flag.Name, ErrDuplicateFlag)
+					err = errors.Join(err, err2)
+				}
+			})
 			allFlags.AddFlagSet(flags)
+			return err
 		})
 	if err != nil {
 		return err

--- a/cell/config_test.go
+++ b/cell/config_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/dig"
+
+	"github.com/cilium/hive/cell"
+)
+
+type testConfig1 struct {
+	OverlappingFlag string
+}
+
+func (cfg testConfig1) Flags(flags *pflag.FlagSet) {
+	flags.String("overlapping-flag", "", "Flag that conflicts with another cell")
+}
+
+type testConfig2 struct {
+	testConfig1
+}
+
+func TestDuplicateFlags(t *testing.T) {
+	orderedCells := []cell.Cell{
+		cell.Config(testConfig1{}),
+		cell.Config(testConfig2{}),
+	}
+	expErrMsgs := []error{
+		nil,                   // testConfig1 is fine
+		cell.ErrDuplicateFlag, // Adding testConfig2 creates duplicate flag
+	}
+
+	container := dig.New(dig.DeferAcyclicVerification())
+	container.Provide(func() *pflag.FlagSet {
+		return pflag.NewFlagSet("", pflag.ContinueOnError)
+	})
+
+	for i, cell := range orderedCells {
+		err := cell.Apply(container, container)
+		assert.ErrorIs(t, err, expErrMsgs[i])
+	}
+
+}


### PR DESCRIPTION
When a hive declares the same configuration multiple times, only one of
them will take effect. In order to prevent resultant bugs, instead
detect and prevent such configuration in the first place.
