### PR TITLE
script: Do not lose flags when retrying command

### DIFF
--- a/script/engine.go
+++ b/script/engine.go
@@ -320,7 +320,8 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 				regexpArgs = usage.RegexpArgs(rawArgs...)
 			}
 		}
-		cmd.args = expandArgs(s, cmd.rawArgs, regexpArgs)
+		cmd.origArgs = expandArgs(s, cmd.rawArgs, regexpArgs)
+		cmd.args = cmd.origArgs
 
 		// Run the command.
 		err = e.runCommand(s, cmd, impl)
@@ -436,6 +437,7 @@ type command struct {
 	conds      []condition // all must be satisfied
 	name       string      // the name of the command; must be non-empty
 	rawArgs    [][]argFragment
+	origArgs   []string // original arguments before pflag parsing
 	args       []string // shell-expanded arguments following name
 	background bool     // command should run in background (ends with a trailing &)
 }
@@ -695,7 +697,7 @@ func (e *Engine) runCommand(s *State, cmd *command, impl Cmd) error {
 	if usage.Flags != nil {
 		usage.Flags(fs)
 	}
-	if err := fs.Parse(cmd.args); err != nil {
+	if err := fs.Parse(cmd.origArgs); err != nil {
 		if errors.Is(err, pflag.ErrHelp) {
 			out := new(strings.Builder)
 			err = e.ListCmds(out, true, "^"+cmd.name+"$")

--- a/script/scripttest/testdata/retry.txt
+++ b/script/scripttest/testdata/retry.txt
@@ -1,0 +1,4 @@
+# Test command retrying and the flag parsing when retrying.
+# The 'retrytest' command should run two times and the flags
+# should not be lost.
+* retrytest --not-empty=xyz abc


### PR DESCRIPTION
Since the parsing of the flags overwrite 'cmd.args' this caused the retry of the command to lose the flags. Keep the original args to the side and use those when parsing the arguments.