### PR TITLE
script: Set origArgs also in ExecuteLine

### DIFF
--- a/script/engine.go
+++ b/script/engine.go
@@ -412,6 +412,7 @@ func (e *Engine) ExecuteLine(s *State, line string, log io.Writer) (err error) {
 		}
 	}
 	cmd.args = expandArgs(s, cmd.rawArgs, regexpArgs)
+	cmd.origArgs = cmd.args
 
 	// Run the command.
 	err = e.runCommand(s, cmd, impl)


### PR DESCRIPTION
The origArgs wasn't set when executing via shell causing all arguments to disappear in interactive use.