### PR TITLE
Rework hive script commands

### DIFF
--- a/cell/info.go
+++ b/cell/info.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -24,13 +23,20 @@ type InfoPrinter struct {
 	width int
 }
 
-func NewInfoPrinter() *InfoPrinter {
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		width = 120
+type fder interface {
+	Fd() uintptr
+}
+
+func NewInfoPrinter(w io.Writer) *InfoPrinter {
+	width := 120
+	if f, ok := w.(fder); ok {
+		widthFd, _, err := term.GetSize(int(f.Fd()))
+		if err == nil {
+			width = widthFd
+		}
 	}
 	return &InfoPrinter{
-		Writer: os.Stdout,
+		Writer: w,
 		width:  width,
 	}
 }

--- a/cell/lifecycle.go
+++ b/cell/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"sync"
 	"time"
@@ -56,7 +57,7 @@ type Lifecycle interface {
 
 	Start(*slog.Logger, context.Context) error
 	Stop(*slog.Logger, context.Context) error
-	PrintHooks()
+	PrintHooks(io.Writer)
 }
 
 // DefaultLifecycle lifecycle implements a simple lifecycle management that conforms
@@ -178,27 +179,27 @@ func (lc *DefaultLifecycle) Stop(log *slog.Logger, ctx context.Context) error {
 	return errs
 }
 
-func (lc *DefaultLifecycle) PrintHooks() {
+func (lc *DefaultLifecycle) PrintHooks(w io.Writer) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
-	fmt.Printf("Start hooks:\n\n")
+	fmt.Fprintf(w, "Start hooks:\n\n")
 	for _, hook := range lc.hooks {
 		fnName, exists := getHookFuncName(hook.HookInterface, true)
 		if !exists {
 			continue
 		}
-		fmt.Printf("  • %s (%s)\n", fnName, hook.moduleID)
+		fmt.Fprintf(w, "  • %s (%s)\n", fnName, hook.moduleID)
 	}
 
-	fmt.Printf("\nStop hooks:\n\n")
+	fmt.Fprintf(w, "\nStop hooks:\n\n")
 	for i := len(lc.hooks) - 1; i >= 0; i-- {
 		hook := lc.hooks[i]
 		fnName, exists := getHookFuncName(hook.HookInterface, false)
 		if !exists {
 			continue
 		}
-		fmt.Printf("  • %s (%s)\n", fnName, hook.moduleID)
+		fmt.Fprintf(w, "  • %s (%s)\n", fnName, hook.moduleID)
 	}
 }
 

--- a/command.go
+++ b/command.go
@@ -4,6 +4,9 @@
 package hive
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +17,7 @@ func (h *Hive) Command() *cobra.Command {
 		Use:   "hive",
 		Short: "Inspect the hive",
 		Run: func(cmd *cobra.Command, args []string) {
-			h.PrintObjects()
+			h.PrintObjects(os.Stdout, slog.Default())
 		},
 		TraverseChildren: false,
 	}

--- a/hivetest/lifecycle.go
+++ b/hivetest/lifecycle.go
@@ -5,6 +5,7 @@ package hivetest
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"testing"
 
@@ -47,7 +48,7 @@ func (lc *lifecycle) Append(hook cell.HookInterface) {
 }
 
 // PrintHooks implements cell.Lifecycle.
-func (*lifecycle) PrintHooks() {
+func (*lifecycle) PrintHooks(io.Writer) {
 	panic("unimplemented")
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -60,16 +60,16 @@ func TestScriptCommands(t *testing.T) {
 	s, err := script.NewState(context.TODO(), "/tmp", nil)
 	require.NoError(t, err, "NewState")
 	script := `
-hive start
+hive/start
 example1
 example2
-hive stop
+hive/stop
 `
 	bio := bufio.NewReader(bytes.NewBufferString(script))
 	var stdout bytes.Buffer
 	err = e.Execute(s, "", bio, &stdout)
 	require.NoError(t, err, "Execute")
 
-	expected := `> hive start.*> example1.*hello1.*> example2.*hello2.*> hive stop`
+	expected := `> hive/start.*> example1.*hello1.*> example2.*hello2.*> hive/stop`
 	require.Regexp(t, expected, strings.ReplaceAll(stdout.String(), "\n", " "))
 }


### PR DESCRIPTION
The 'hive' command now prints objects. The 'hive start' and 'hive stop' are kept for backwards compatibility.

'hive/start' and 'hive/stop' are added to reflect the new style (flat commands, no sub-commands, thus better help).