### PR TITLE
script: Exponential backoff for retrying

### DIFF
--- a/script/scripttest/scripttest_test.go
+++ b/script/scripttest/scripttest_test.go
@@ -22,10 +22,11 @@ func TestAll(t *testing.T) {
 	env := os.Environ()
 	scripttest.Test(t, ctx, func(t testing.TB, scriptArgs []string) *script.Engine {
 		engine := &script.Engine{
-			Conds:         scripttest.DefaultConds(),
-			Cmds:          scripttest.DefaultCmds(),
-			Quiet:         !testing.Verbose(),
-			RetryInterval: 10 * time.Millisecond,
+			Conds:            scripttest.DefaultConds(),
+			Cmds:             scripttest.DefaultCmds(),
+			Quiet:            !testing.Verbose(),
+			RetryInterval:    10 * time.Millisecond,
+			MaxRetryInterval: 100 * time.Millisecond,
 		}
 		engine.Cmds["args"] = script.Command(
 			script.CmdUsage{},


### PR DESCRIPTION
It's easy to get pretty spammy logs when failing retried commands. We don't expect the need to retry many times in successful tests, so add an exponential backoff to make the output more reasonable on failures.