### PR TITLE
script: Retry related fixes

### DIFF
--- a/script/cmds.go
+++ b/script/cmds.go
@@ -256,9 +256,10 @@ func doCompare(s *State, env bool, args ...string) error {
 	}
 
 	if text1 != text2 {
-		if s.DoUpdate {
-			// Updates requested, store the file contents and
-			// ignore mismatches.
+		if s.DoUpdate && s.RetryCount > 0 {
+			// Updates requested and we've already retried at least once
+			// (and given time for things to settle down).
+			// Store the file contents and ignore the mismatch.
 			s.FileUpdates[name1] = text2
 			s.FileUpdates[name2] = text1
 			return nil

--- a/script/engine.go
+++ b/script/engine.go
@@ -198,6 +198,10 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 	if retryInterval == 0 {
 		retryInterval = defaultRetryInterval
 	}
+	maxRetryInterval := e.MaxRetryInterval
+	if maxRetryInterval == 0 {
+		maxRetryInterval = defaultMaxRetryInterval
+	}
 
 	var (
 		sectionStart time.Time
@@ -338,7 +342,7 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 			if cmd.want == successRetryOnFailure || cmd.want == failureRetryOnSuccess {
 				// Command wants retries. Retry the whole section
 				numRetries := 0
-				backoff := exponentialBackoff{max: e.MaxRetryInterval, interval: e.RetryInterval}
+				backoff := exponentialBackoff{max: maxRetryInterval, interval: retryInterval}
 				for err != nil {
 					s.FlushLog()
 					retryDuration := backoff.get()

--- a/script/engine.go
+++ b/script/engine.go
@@ -335,13 +335,13 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 		}
 		cmd.origArgs = expandArgs(s, cmd.rawArgs, regexpArgs)
 		cmd.args = cmd.origArgs
+		s.RetryCount = 0
 
 		// Run the command.
 		err = e.runCommand(s, cmd, impl)
 		if err != nil {
 			if cmd.want == successRetryOnFailure || cmd.want == failureRetryOnSuccess {
 				// Command wants retries. Retry the whole section
-				numRetries := 0
 				backoff := exponentialBackoff{max: maxRetryInterval, interval: retryInterval}
 				for err != nil {
 					s.FlushLog()
@@ -349,10 +349,11 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 					s.Logf("(command %q failed, retrying in %s...)\n", line, retryDuration)
 					select {
 					case <-s.Context().Done():
+						s.RetryCount = 0
 						return lineErr(s.Context().Err())
 					case <-time.After(retryDuration):
 					}
-					numRetries++
+					s.RetryCount++
 					for _, cmd := range sectionCmds {
 						impl := e.Cmds[cmd.name]
 						if err = e.runCommand(s, cmd, impl); err != nil {
@@ -360,7 +361,8 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 						}
 					}
 				}
-				s.Logf("(command %q succeeded after %d retries)\n", line, numRetries)
+				s.Logf("(command %q succeeded after %d retries)\n", line, s.RetryCount)
+				s.RetryCount = 0
 			} else {
 				if stop := (stopError{}); errors.As(err, &stop) {
 					// Since the 'stop' command halts execution of the entire script,

--- a/script/state.go
+++ b/script/state.go
@@ -40,6 +40,7 @@ type State struct {
 	Flags       *pflag.FlagSet
 	DoUpdate    bool
 	FileUpdates map[string]string
+	RetryCount  int
 
 	BreakOnError bool
 


### PR DESCRIPTION
* Use the default retry intervals if they're zero
* Require at least one retry before taking the output with `-scripttest.update`