### PR TITLE
script: Fix lack of newline on retried command in logs

### DIFF
--- a/script/scripttest/scripttest_test.go
+++ b/script/scripttest/scripttest_test.go
@@ -46,6 +46,7 @@ func TestAll(t *testing.T) {
 				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				s.Logf("retrytest called")
 				notEmpty, err := s.Flags.GetString("not-empty")
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Fix lack of newline on retried command in logs and show the amount of time it took until retries succeeded.

Before:
```
    scripttest.go:72: # Test command retrying and the flag parsing when retrying.
        # The 'retrytest' command should run two times and the flags
        # should not be lost.> * retrytest --not-empty=xyz abc
    scripttest.go:72:  (0.010s)
        (command "* retrytest --not-empty=xyz abc" failed, retrying in 10ms...)
        (command "* retrytest --not-empty=xyz abc" succeeded after 1 retries)
    --- PASS: TestAll/retry (0.01s)
```
After:
```
    scripttest.go:72: # Test command retrying and the flag parsing when retrying.
        # The 'retrytest' command should run two times and the flags
        # should not be lost.
        > * retrytest --not-empty=xyz abc
        retrytest called
    scripttest.go:72: (command "* retrytest --not-empty=xyz abc" failed, retrying in 10ms...)
        retrytest called
    scripttest.go:72: (command "* retrytest --not-empty=xyz abc" succeeded after 1 retries in 0.010s)
    --- PASS: TestAll/retry (0.01s)
```