### PR TITLE
Improve error reporting for Populate()

### DIFF
--- a/cell/invoke.go
+++ b/cell/invoke.go
@@ -49,7 +49,7 @@ func (inv *invoker) invoke(log *slog.Logger, cont container, logThreshold time.D
 		defer inv.funcs[i].infoMu.Unlock()
 
 		if err := cont.Invoke(nf.fn, opts...); err != nil {
-			log.Error("Invoke failed", "error", err, "function", nf.name)
+			log.Error("Invoke failed", "error", dig.RootCause(err), "function", nf.name)
 			return err
 		}
 		d := time.Since(t0)

--- a/command.go
+++ b/command.go
@@ -14,10 +14,11 @@ import (
 // command can be used to inspect the dependency graph.
 func (h *Hive) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "hive",
-		Short: "Inspect the hive",
-		Run: func(cmd *cobra.Command, args []string) {
-			h.PrintObjects(os.Stdout, slog.Default())
+		Use:          "hive",
+		Short:        "Inspect the hive",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return h.PrintObjects(os.Stdout, slog.Default())
 		},
 		TraverseChildren: false,
 	}
@@ -25,10 +26,11 @@ func (h *Hive) Command() *cobra.Command {
 
 	cmd.AddCommand(
 		&cobra.Command{
-			Use:   "dot-graph",
-			Short: "Output the dependencies graph in graphviz dot format",
-			Run: func(cmd *cobra.Command, args []string) {
-				h.PrintDotGraph()
+			Use:          "dot-graph",
+			Short:        "Output the dependencies graph in graphviz dot format",
+			SilenceUsage: true,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return h.PrintDotGraph()
 			},
 			TraverseChildren: false,
 		})

--- a/script.go
+++ b/script.go
@@ -82,8 +82,8 @@ func hiveScriptCmd(h *Hive, log *slog.Logger) script.Cmd {
 				defer cancel()
 				return nil, h.Stop(log, ctx)
 			default:
-				h.PrintObjects(s.LogWriter(), log)
-				return nil, nil
+				err := h.PrintObjects(s.LogWriter(), log)
+				return nil, err
 			}
 		},
 	)


### PR DESCRIPTION
Show the pretty-printed error from populating the object graph in PrintObjects() and PrintDotGraph(). Add the ErrPopulate so we can add special casing for it in cilium/cilium to also do the pretty-printing of the error there.

Will look like this instead of just being a one-liner:
```
Failed to populate object graph:
could not build arguments for function "github.com/cilium/cilium/daemon/cmd".configureAPIServer
        /home/jussi/go/src/github.com/cilium/cilium/daemon/cmd/cells.go:330:
failed to build *server.Server:
could not build arguments for function "github.com/cilium/cilium/api/v1/server".newForCell
        /home/jussi/go/src/github.com/cilium/cilium/api/v1/server/server.go:206:
failed to build *restapi.CiliumAPIAPI:
could not build arguments for function "github.com/cilium/cilium/api/v1/server".newAPI
        /home/jussi/go/src/github.com/cilium/cilium/api/v1/server/server.go:125:
failed to build endpoint.DeleteEndpointHandler:
could not build arguments for function "github.com/cilium/cilium/daemon/cmd".ciliumAPIHandlers
        /home/jussi/go/src/github.com/cilium/cilium/daemon/cmd/api_handlers.go:81:
failed to build promise.Promise[*github.com/cilium/cilium/daemon/cmd.Daemon]: could not build arguments for function "github.com/cilium/cilium/daemon/cmd".newDaemonPromise
        /home/jussi/go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1585:
failed to build *clustermesh.ClusterMesh:
could not build arguments for function "github.com/cilium/cilium/pkg/clustermesh".NewClusterMesh
        /home/jussi/go/src/github.com/cilium/cilium/pkg/clustermesh/clustermesh.go:133:
failed to build *dial.ServiceResolver:
missing dependencies for function "github.com/cilium/cilium/pkg/dial".newServiceResolver
        /home/jussi/go/src/github.com/cilium/cilium/pkg/dial/resolver.go:43:
missing type:
        - resource.Resource[*github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1.Service] (did you mean to Provide it?)
 ```