### PR TITLE
script: After retry we should not stop executing further commands

### DIFF
--- a/script/engine.go
+++ b/script/engine.go
@@ -372,7 +372,6 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 				}
 				fmt.Fprintf(log, "(command %q succeeded after %d retries in %.3fs)\n", line, s.RetryCount, time.Since(retryStart).Seconds())
 				s.RetryCount = 0
-				return nil
 			} else {
 				if stop := (stopError{}); errors.As(err, &stop) {
 					// Since the 'stop' command halts execution of the entire script,


### PR DESCRIPTION
This was accidentally introduced in previous commit.

Fixes: 08596a874b92 ("script: Fix lack of newline on retried command in logs")