### PR TITLE
script: add empty command.

### DIFF
--- a/script/scripttest/testdata/empty.txt
+++ b/script/scripttest/testdata/empty.txt
@@ -1,0 +1,10 @@
+empty isempty
+
+# Test stdout facility
+empty stdout
+
+# Test trim option
+echo
+empty --trim stdout
+
+-- isempty --


### PR DESCRIPTION
Simple command that checks if file or output streams are empty.

This provides quality-of-life improvement over having to define a empty file and 'cmp' against that.