### PR TITLE
Add AppendWithModuleID to DefaultLifecycle

### DIFF
--- a/cell/lifecycle.go
+++ b/cell/lifecycle.go
@@ -90,10 +90,14 @@ func NewDefaultLifecycle(hooks []HookInterface, numStarted int, logThreshold tim
 }
 
 func (lc *DefaultLifecycle) Append(hook HookInterface) {
+	lc.AppendWithModuleID(hook, nil)
+}
+
+func (lc *DefaultLifecycle) AppendWithModuleID(hook HookInterface, mid FullModuleID) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
-	lc.hooks = append(lc.hooks, augmentedHook{hook, nil})
+	lc.hooks = append(lc.hooks, augmentedHook{hook, mid})
 }
 
 func (lc *DefaultLifecycle) Start(log *slog.Logger, ctx context.Context) error {
@@ -209,10 +213,7 @@ type augmentedLifecycle struct {
 }
 
 func (lc augmentedLifecycle) Append(hook HookInterface) {
-	lc.mu.Lock()
-	defer lc.mu.Unlock()
-
-	lc.hooks = append(lc.hooks, augmentedHook{hook, lc.moduleID})
+	lc.AppendWithModuleID(hook, lc.moduleID)
 }
 
 func getHookFuncName(hook HookInterface, start bool) (name string, hasHook bool) {


### PR DESCRIPTION
In cilium/cilium the job groups were provided for each module and its lifecycle hooks appended when constructed. This is problematic when the job group is used multiple times as then the dependencies of the later uses won't influence the order in which start hooks run, e.g. if a later job depends on X it might happen that the job is started before X is started.

To fix this, we'll make the job groups start as the very last thing in the lifecycle which ensures all the start hooks of provided objects are run.

For that we'll need to use a separate lifecycle for the job groups and to keep the output nice we'll need to be able to provide the module ID when appending the job group hooks. This commit exposes 'AppendWithModuleID' which we can use to do that.