### PR TITLE
script: Refuse empty files in cmp when updating

### DIFF
--- a/script/engine.go
+++ b/script/engine.go
@@ -336,11 +336,12 @@ func (e *Engine) Execute(s *State, file string, script *bufio.Reader, log io.Wri
 		cmd.origArgs = expandArgs(s, cmd.rawArgs, regexpArgs)
 		cmd.args = cmd.origArgs
 		s.RetryCount = 0
+		s.retriesRequested = cmd.want == successRetryOnFailure || cmd.want == failureRetryOnSuccess
 
 		// Run the command.
 		err = e.runCommand(s, cmd, impl)
 		if err != nil {
-			if cmd.want == successRetryOnFailure || cmd.want == failureRetryOnSuccess {
+			if s.retriesRequested {
 				retryStart := sectionStart
 
 				// Clear the section start to avoid the deferred endSection() printing a timestamp.

--- a/script/state.go
+++ b/script/state.go
@@ -42,6 +42,8 @@ type State struct {
 	FileUpdates map[string]string
 	RetryCount  int
 
+	retriesRequested bool
+
 	BreakOnError bool
 
 	background []backgroundCmd


### PR DESCRIPTION
Add an additional safeguard to -scripttest.update when used with 'cmp' to ignore empty files and increase the retries to 2. This significantly increases the likelyhood that we do not pick a too "early" version of the actual output.

Removed the update handling from 'empty' command as I don't see a use-case where we'd use 'empty' on a file within the txtar. You can just empty the file manually.