### PR TITLE
Revert "cell: migrate to github.com/go-viper/mapstructure/v2"

### DIFF
--- a/cell/config.go
+++ b/cell/config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/cilium/hive/internal"
-	"github.com/go-viper/mapstructure/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"go.uber.org/dig"
 )
@@ -41,7 +41,7 @@ type Flagger interface {
 	// Exported fields that are not found from the viper settings will cause
 	// hive.Run() to fail. Unexported fields are ignored.
 	//
-	// See https://pkg.go.dev/github.com/go-viper/mapstructure/v2 for more info.
+	// See https://pkg.go.dev/github.com/mitchellh/mapstructure for more info.
 	Flags(*pflag.FlagSet)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.3
 require (
 	github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/go-viper/mapstructure/v2 v2.2.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -13,8 +13,6 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/dig v1.17.1
 	go.uber.org/goleak v1.3.0
-	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
-	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
 	golang.org/x/tools v0.16.0
 )
@@ -25,7 +23,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
@@ -35,6 +32,8 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
+	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
-github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=


### PR DESCRIPTION
Reverts cilium/hive#49

The "go-viper/mapstructure/v2" is not compatible with "mitchellh/mapstructure":
```
--- FAIL: TestNodeAddressWhitelist (0.01s)
    --- FAIL: TestNodeAddressWhitelist/v4-v6_mix (0.00s)
        logger.go:256: time=2025-05-22T16:44:34.236+02:00 level=ERROR source=/home/jussi/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/cell/invoke.go:52 msg="Invoke failed" error="failed to unmarshal config struct tables.NodeAddressConfig: decoding failed due to the following error(s):\n\nerror decoding 'nodeport-addresses[0]': netip.ParsePrefix(\"2001::/16,10.0.0.0/8\"): ParseAddr(\"2001::/16,10.0.0.0\"): each colon-separated field must have at least one digit (at \"/16,10.0.0.0\").\nHint: field 'FooBar' matches flag 'foo-bar', or use tag `mapstructure:\"flag-name\"` to match field with flag" function="tables.fixture.func2 (.../datapath/tables/node_address_test.go:802)"
        node_address_test.go:823:
                Error Trace:    /home/jussi/go/src/github.com/cilium/cilium/pkg/datapath/tables/node_address_test.go:823
                                                        /home/jussi/go/src/github.com/cilium/cilium/pkg/datapath/tables/node_address_test.go:592
                Error:          Received unexpected error:
                                failed to populate object graph: failed to unmarshal config struct tables.NodeAddressConfig: decoding failed due to the following error(s):

                                error decoding 'nodeport-addresses[0]': netip.ParsePrefix("2001::/16,10.0.0.0/8"): ParseAddr("2001::/16,10.0.0.0"): each colon-separated field must have at least one digit (at "/16,10.0.0.0").
                                Hint: field 'FooBar' matches flag 'foo-bar', or use tag `mapstructure:"flag-name"` to match field with flag
                Test:           TestNodeAddressWhitelist/v4-v6_mix
                Messages:       Start
FAIL
FAIL    github.com/cilium/cilium/pkg/datapath/tables    1.146s
FAIL
```

As I'm bumping Hive and StateDB for other critical reasons I'm proposing we revert this change and fix this later.