### PR TITLE
change hive Stop message

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -371,7 +371,14 @@ func (h *Hive) Start(log *slog.Logger, ctx context.Context) error {
 func (h *Hive) Stop(log *slog.Logger, ctx context.Context) error {
 	defer close(h.fatalOnTimeout(ctx))
 	log.Info("Stopping hive")
-	return h.lifecycle.Stop(log, ctx)
+	start := time.Now()
+	err := h.lifecycle.Stop(log, ctx)
+	if err == nil {
+		log.Info("Stopped hive", "duration", time.Since(start))
+	} else {
+		log.Error("Failed to stop hive", "error", err, "duration", time.Since(start))
+	}
+	return err
 }
 
 func (h *Hive) fatalOnTimeout(ctx context.Context) chan struct{} {


### PR DESCRIPTION
Change hive.Stop() to log with the same pattern as Start(). These actions should basically mirror each other.