### PR TITLE
Add the exit code on error

### DIFF
--- a/shell/client.go
+++ b/shell/client.go
@@ -97,6 +97,7 @@ func ShellExchange(c Config, w io.Writer, format string, args ...any) error {
 			continue
 		}
 		line, ended := strings.CutSuffix(line, endMarker)
+		line, errored := strings.CutSuffix(line, errorMarker)
 		if isPrefix {
 			// Partial line, don't print \n yet.
 			_, err = fmt.Fprint(w, line)
@@ -109,6 +110,9 @@ func ShellExchange(c Config, w io.Writer, format string, args ...any) error {
 		if ended {
 			return nil
 		}
+		if errored {
+			return errors.New(line)
+		}
 	}
 }
 
@@ -117,6 +121,7 @@ func executeShell(cfg Config, prompt string, printGreeting func(io.Writer), args
 		err := ShellExchange(cfg, os.Stdout, "%s", strings.Join(args, " "))
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "error: %s\n", err)
+			os.Exit(1)
 		}
 	} else {
 		os.Exit(interactiveShell(cfg, prompt, printGreeting))

--- a/shell/const.go
+++ b/shell/const.go
@@ -7,6 +7,10 @@ const (
 	// endMarker marks the end of output from a command.
 	endMarker = "<<end>>"
 
+	// errorMarker marks the command as failed. If the command
+	// fails this acts as the end of output mark.
+	errorMarker = "<<error>>"
+
 	// stdoutMarker marks the output to be from the stdout buffer.
 	stdoutMarker = "[stdout]"
 

--- a/shell/server.go
+++ b/shell/server.go
@@ -173,15 +173,17 @@ func (sh shell) handleConn(ctx context.Context, clientID int, conn net.Conn) {
 		}
 		err = sh.engine.ExecuteLine(s, line, writer)
 		if err != nil {
-			_, err = fmt.Fprintln(writer, err)
+			// Send the error and the error marker
+			_, err = fmt.Fprintf(writer, "%s%s\n", err, errorMarker)
 			if err != nil {
 				break
 			}
-		}
-		// Send the "end of command output" marker
-		_, err = fmt.Fprintln(writer, endMarker)
-		if err != nil {
-			break
+		} else {
+			// Send the "end of command output" marker
+			_, err = fmt.Fprintln(writer, endMarker)
+			if err != nil {
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
Update the exit code when we see an error in executing a cmd in the shell.