### PR TITLE
job: Restore the NewGroup type signature

### DIFF
--- a/example/events.go
+++ b/example/events.go
@@ -84,7 +84,7 @@ func newExampleEvents(lc cell.Lifecycle, jobs job.Registry, health cell.Health) 
 	es.Observable, es.emit, es.complete = stream.Multicast[ExampleEvent]()
 
 	// Create a new job group and add emitter as a one-shot job.
-	g := jobs.NewGroup(health)
+	g := jobs.NewGroup(health, lc)
 	g.Add(job.OneShot("emitter", es.emitter))
 	return es
 }

--- a/job/job.go
+++ b/job/job.go
@@ -31,10 +31,15 @@ var Cell = cell.Module(
 // A Registry creates Groups, it maintains references to these groups for the purposes of collecting information
 // centralized like metrics.
 type Registry interface {
-	// NewGroup creates a new group of jobs which can be started and stopped together as part of the cells lifecycle.
-	// The provided scope is used to report health status of the jobs. A `cell.Scope` can be obtained via injection
-	// an object with the correct scope is provided by the closest `cell.Module`.
-	NewGroup(health cell.Health, opts ...groupOpt) Group
+	// NewGroup creates a new Group with the given `opts` options, which allows you to customize the behavior for the
+	// group as a whole. For example by allowing you to add pprof labels to the group or by customizing the logger.
+	//
+	// Jobs added to the group before it is started will be appended to the registry's lifecycle.
+	// Jobs added after starting are started immediately and stopped sequentially in reverse order
+	// when registry is stopped.
+	//
+	// The lifecycle is no longer used but kept for backwards compatibility.
+	NewGroup(health cell.Health, _ cell.Lifecycle, opts ...groupOpt) Group
 }
 
 type registry struct {
@@ -94,7 +99,9 @@ func (c *registry) Stop(ctx cell.HookContext) error {
 // Jobs added to the group before it is started will be appended to the registry's lifecycle.
 // Jobs added after starting are started immediately and stopped sequentially in reverse order
 // when registry is stopped.
-func (c *registry) NewGroup(health cell.Health, opts ...groupOpt) Group {
+//
+// The lifecycle is no longer used but kept for backwards compatibility.
+func (c *registry) NewGroup(health cell.Health, _ cell.Lifecycle, opts ...groupOpt) Group {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -59,8 +59,8 @@ func TestRegistry(t *testing.T) {
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
 		r1 = r
-		g1 = r.NewGroup(s)
-		g2 = r.NewGroup(s)
+		g1 = r.NewGroup(s, l)
+		g2 = r.NewGroup(s, l)
 	})
 	h.Populate(hivetest.Logger(t))
 
@@ -83,7 +83,7 @@ func TestGroup_JobPreStart(t *testing.T) {
 	}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 		g.Add(
 			OneShot("queued1", incFunc),
 			OneShot("queued2", incFunc),
@@ -112,7 +112,7 @@ func TestGroup_JobRuntime(t *testing.T) {
 	)
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 	})
 
 	h.Start(slog.Default(), context.Background())
@@ -148,8 +148,8 @@ func TestJobLifecycleOrderingAcrossGroups(t *testing.T) {
 	}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g1 = r.NewGroup(s)
-		g2 = r.NewGroup(s)
+		g1 = r.NewGroup(s, l)
+		g2 = r.NewGroup(s, l)
 
 		addJob(g1, "g1-first")
 		addJob(g1, "g1-second")
@@ -185,7 +185,7 @@ func TestModuleDecoratedGroup(t *testing.T) {
 	opts := hive.DefaultOptions()
 	opts.ModulePrivateProviders = cell.ModulePrivateProviders{
 		func(r Registry, h cell.Health, modID cell.FullModuleID, l *slog.Logger, lc cell.Lifecycle) Group {
-			g := r.NewGroup(h,
+			g := r.NewGroup(h, lc,
 				WithLogger(l),
 				WithPprofLabels(pprof.Labels("module", modID.String())))
 			return g

--- a/job/observer_test.go
+++ b/job/observer_test.go
@@ -26,7 +26,7 @@ func TestObserver_ShortStream(t *testing.T) {
 	streamSlice := []string{"a", "b", "c"}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(
 			Observer("retry-fail", func(ctx context.Context, event string) error {
@@ -66,7 +66,7 @@ func TestObserver_LongStream(t *testing.T) {
 	inChan := make(chan struct{})
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(
 			Observer("retry-fail", func(ctx context.Context, _ struct{}) error {
@@ -100,7 +100,7 @@ func TestObserver_CtxClose(t *testing.T) {
 	streamSlice := []string{"a", "b", "c"}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Observer("retry-fail", func(ctx context.Context, event string) error {

--- a/job/oneshot_test.go
+++ b/job/oneshot_test.go
@@ -25,7 +25,7 @@ func TestOneShot_ShortRun(t *testing.T) {
 	stop := make(chan struct{})
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("short", func(ctx context.Context, health cell.Health) error {
@@ -50,7 +50,7 @@ func TestOneShot_LongRun(t *testing.T) {
 	stopped := make(chan struct{})
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("long", func(ctx context.Context, health cell.Health) error {
@@ -83,7 +83,7 @@ func TestOneShot_RetryFail(t *testing.T) {
 	rateLimiter := &ExponentialBackoff{Min: 10 * time.Millisecond, Max: 20 * time.Millisecond}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("retry-fail", func(ctx context.Context, health cell.Health) error {
@@ -148,7 +148,7 @@ func testOneShot_RetryBackoff(t *testing.T) (bool, error) {
 	rateLimiter := &ExponentialBackoff{Min: retryMin, Max: retryMax}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(OneShot("retry-backoff", func(ctx context.Context, health cell.Health) error {
 			timesMu.Lock()
@@ -210,7 +210,7 @@ func TestOneShot_RetryRecover(t *testing.T) {
 	rateLimiter := &ExponentialBackoff{Min: 10 * time.Millisecond, Max: 20 * time.Millisecond}
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("retry-recover", func(ctx context.Context, health cell.Health) error {
@@ -248,7 +248,7 @@ func TestOneShot_Shutdown(t *testing.T) {
 
 	targetErr := errors.New("Always error")
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("shutdown", func(ctx context.Context, health cell.Health) error {
@@ -275,7 +275,7 @@ func TestOneShot_RetryFailShutdown(t *testing.T) {
 
 	targetErr := errors.New("Always error")
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("retry-fail-shutdown", func(ctx context.Context, health cell.Health) error {
@@ -310,7 +310,7 @@ func TestOneShot_RetryRecoverNoShutdown(t *testing.T) {
 	const retries = 5
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 	})
 
 	log := hivetest.Logger(t)
@@ -367,7 +367,7 @@ func TestOneShot_RetryWhileShuttingDown(t *testing.T) {
 	shutdown := make(chan struct{})
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g = r.NewGroup(s)
+		g = r.NewGroup(s, l)
 
 		g.Add(
 			OneShot("retry-context-closed", func(ctx context.Context, health cell.Health) error {

--- a/job/timer_test.go
+++ b/job/timer_test.go
@@ -24,7 +24,7 @@ func TestTimer_OnInterval(t *testing.T) {
 	var i atomic.Int32
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -61,7 +61,7 @@ func TestTimer_Trigger(t *testing.T) {
 	trigger := NewTrigger()
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -108,7 +108,7 @@ func TestTimer_DoubleTrigger(t *testing.T) {
 	trigger := NewTrigger()
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -157,7 +157,7 @@ func TestTimer_TriggerDebounce(t *testing.T) {
 	trigger := NewTrigger(WithDebounce(time.Hour))
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -209,7 +209,7 @@ func TestTimer_TriggerOnly(t *testing.T) {
 	trigger := NewTrigger()
 
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -251,7 +251,7 @@ func TestTimer_ExitOnClose(t *testing.T) {
 
 	var i atomic.Int32
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
@@ -283,7 +283,7 @@ func TestTimer_ExitOnCloseFnCtx(t *testing.T) {
 	var i atomic.Int32
 	started := make(chan struct{})
 	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
-		g := r.NewGroup(s)
+		g := r.NewGroup(s, l)
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {

--- a/shell/server.go
+++ b/shell/server.go
@@ -38,7 +38,7 @@ var defaultCmdsToInclude = []string{
 }
 
 func registerShell(in hive.ScriptCmds, log *slog.Logger, lc cell.Lifecycle, jobs job.Registry, health cell.Health, c Config) {
-	jg := jobs.NewGroup(health)
+	jg := jobs.NewGroup(health, lc)
 
 	if c.ShellSockPath == "" {
 		log.Info("Shell socket path not set, not starting shell server")

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -46,7 +46,7 @@ func fixture(t *testing.T, cfg Config) {
 		cell.SimpleHealthCell,
 		cell.Provide(
 			func(r job.Registry, lc cell.Lifecycle, health cell.Health) job.Group {
-				return r.NewGroup(health)
+				return r.NewGroup(health, lc)
 			},
 		),
 		ServerCell(cfg.ShellSockPath),


### PR DESCRIPTION
Dropping the lifecycle parameter from NewGroup causes quite a bit of disturbance due to cilium/hive being unversioned. Let's restore the old type until cilium/hive is versioned and breaking API change can be rolled out without trouble.