### PR TITLE
job: Add `WithObserverShutdown` option for observer jobs

### DIFF
--- a/hive.go
+++ b/hive.go
@@ -224,7 +224,7 @@ func AddConfigOverride[Cfg cell.Flagger](h *Hive, override func(*Cfg)) {
 }
 
 // RunOptionFunc is a functional option type for configuring hive on Run stage.
-type RunOptionFunc func (*Hive)
+type RunOptionFunc func(*Hive)
 
 // WithStartTimeout overrides hive StartTimeout option.
 func WithStartTimeout(timeout time.Duration) RunOptionFunc {

--- a/hive_test.go
+++ b/hive_test.go
@@ -428,15 +428,15 @@ func TestTimeoutOverride(t *testing.T) {
 	var started, stopped int
 	opts := hive.DefaultOptions()
 
-	newStartTimeout := 3*time.Millisecond
-	newStopTimeout := 2*time.Millisecond
+	newStartTimeout := 3 * time.Millisecond
+	newStopTimeout := 2 * time.Millisecond
 
 	h := hive.NewWithOptions(
 		opts,
 		cell.Invoke(func(lc cell.Lifecycle, shutdowner hive.Shutdowner) {
 			lc.Append(cell.Hook{
 				OnStart: func(ctx cell.HookContext) error {
-					started ++
+					started++
 
 					deadline, ok := ctx.Deadline()
 					assert.True(t, ok, "expected start context to have a deadline")
@@ -448,7 +448,7 @@ func TestTimeoutOverride(t *testing.T) {
 					return nil
 				},
 				OnStop: func(ctx cell.HookContext) error {
-					stopped ++
+					stopped++
 
 					deadline, ok := ctx.Deadline()
 					assert.True(t, ok, "expexted stop context to have a deadline")

--- a/job/observer.go
+++ b/job/observer.go
@@ -42,6 +42,14 @@ type ObserverFunc[T any] func(ctx context.Context, event T) error
 
 type observerOpt[T any] func(*jobObserver[T])
 
+// WithObserverShutdown option configures an observer job to shutdown the whole
+// hive if the observer function returns a non-nil, non-context.Canceled error.
+func WithObserverShutdown[T any]() observerOpt[T] {
+	return func(jo *jobObserver[T]) {
+		jo.shutdownOnError = true
+	}
+}
+
 type jobObserver[T any] struct {
 	name string
 	fn   ObserverFunc[T]
@@ -52,7 +60,8 @@ type jobObserver[T any] struct {
 	observable stream.Observable[T]
 
 	// If not nil, call the shutdowner on error
-	shutdown hive.Shutdowner
+	shutdown        hive.Shutdowner
+	shutdownOnError bool
 }
 
 func (jo *jobObserver[T]) info() string {
@@ -62,6 +71,10 @@ func (jo *jobObserver[T]) info() string {
 func (jo *jobObserver[T]) start(ctx context.Context, health cell.Health, options options) {
 	for _, opt := range jo.opts {
 		opt(jo)
+	}
+
+	if jo.shutdownOnError && options.shutdowner != nil {
+		jo.shutdown = options.shutdowner
 	}
 
 	jo.health = health.NewScope("observer-job-" + jo.name)

--- a/job/observer_test.go
+++ b/job/observer_test.go
@@ -5,6 +5,7 @@ package job
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -124,4 +125,24 @@ func TestObserver_CtxClose(t *testing.T) {
 	if err := h.Stop(log, context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// This test asserts that returning an error from an observer job with the
+// WithObserverShutdown option will shutdown the hive.
+func TestObserver_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	targetErr := errors.New("observer error")
+	h := fixture(func(r Registry, s cell.Health, l cell.Lifecycle) {
+		g := r.NewGroup(s)
+
+		g.Add(
+			Observer("shutdown", func(ctx context.Context, event string) error {
+				return targetErr
+			}, stream.FromSlice([]string{"a"}), WithObserverShutdown[string]()),
+		)
+	})
+
+	err := h.Run(hivetest.Logger(t))
+	assert.ErrorIs(t, err, targetErr)
 }


### PR DESCRIPTION
Add a `WithObserverShutdown` option that configures an observer job to trigger a hive shutdown when the observer function returns a non-nil error. This brings observer jobs to parity with `OneShot` jobs, which already support `WithShutdown()`.

The observer struct already had a `shutdown` field and the error-handling code path to call it, but there was no exported option to wire it up. `WithObserverShutdown` fills this gap by connecting the group's shutdowner to the observer during `start()`.

Without this option, an error returned from an observer callback only logs the error and marks health as degraded, but the hive continues running. This is appropriate for transient errors, but not for fatal misconfigurations where continuing would cause silent data-plane breakage.

Motivating example from `cilium/cilium`: the CRD IPAM allocator auto-detects the IPv4 native routing CIDR from the VPC CIDR on ENI nodes. If the user-configured native routing CIDR does not contain the VPC CIDR, the agent calls `logging.Fatal()` ([here](https://github.com/cilium/cilium/blob/f1a4dc509025bf527e4cd7fbc0faeb3f10eb9f83/pkg/ipam/crd.go#L300)), causing a process crash, because running with broken masquerading silently drops cross-node pod traffic. I am currently working on moving this validation to a `job.Observer` callback and would prefer to be able to use error forwarding and get a clean hive shutdown via the observer job's `WithObserverShutdown` rather than keep this `logging.Fatal()` which essentially causes a panic.