### PR TITLE
shell: Fix error handling in interactive shell

### DIFF
--- a/shell/client.go
+++ b/shell/client.go
@@ -235,12 +235,13 @@ repl:
 			}
 
 			line, ended := strings.CutSuffix(line, endMarker)
+			line, errored := strings.CutSuffix(line, errorMarker)
 			if isPrefix {
 				fmt.Fprint(console, line)
 			} else {
 				fmt.Fprintln(console, line)
 			}
-			if ended {
+			if ended || errored {
 				break
 			}
 		}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -93,10 +93,11 @@ func TestInteractiveShell(t *testing.T) {
 
 	// Interactive use
 	cmd := exec.Command(os.Args[0], "-client", sock)
-	cmd.Stdin = strings.NewReader("help help\r\nexit\r\n")
+	cmd.Stdin = strings.NewReader("unknown\r\nhelp help\r\nexit\r\n")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "CombinedOutput")
 
+	require.Contains(t, string(out), "unknown: unknown command")
 	require.Contains(t, string(out), "test> help help")
 	require.Contains(t, string(out), "log help text")
 


### PR DESCRIPTION
interactiveShell() did not check for the `<<error>>` marker which caused it to wait for more input instead of returning to the prompt:

```
   example> aoeu
   <stdin>:0: aoeu unknown command<<error>>
```

Fix this by checking for `<<error>>` and treating it as an end marker in interactive shell.