### PR TITLE
shell: Do not close health reporter

### DIFF
--- a/shell/server.go
+++ b/shell/server.go
@@ -102,7 +102,6 @@ func (sh shell) listener(ctx context.Context, health cell.Health) error {
 			fmt.Sprintf("shell-%d", connID),
 			func(ctx context.Context, h cell.Health) error {
 				sh.handleConn(ctx, connID, conn)
-				h.Close() // remove from health list
 				return nil
 			}))
 	}


### PR DESCRIPTION
Since 09dc693f91c173913172b19cf8f4113101aa2cec the health reporter for jobs are closed automatically. Remove the unnecessary Close() from the shell job that was shadowing the one from jobs.