### PR TITLE
job: Don't unset started when registry stops

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -94,7 +94,6 @@ func (c *registry) Stop(ctx cell.HookContext) error {
 	if !c.started {
 		return nil
 	}
-	c.started = false
 	return c.runtimeLifecycle.stop(ctx, c.logger)
 }
 


### PR DESCRIPTION
By setting 'started = false' any jobs added after the registry has stopped could get appended to the application lifecycle.

This can be hit by having a job added before starting that tries to add a job at runtime. That job is stopped after the registry and thus has time to call JobGroup.Add. It is possible to deadlock by stopping at the same time: Hive.Stop has locked the lifecycle mutex and appending is not possible and if job tries to append to the lifecycle before its stop hook gets called it'll deadlock.

There is no use-case for making the registry restartable so just remove setting started to false completely.