### PR TITLE
cell: Decode config fields implementing `encoding.TextUnmarshaler`

### DIFF
--- a/cell/config.go
+++ b/cell/config.go
@@ -103,6 +103,14 @@ func provideConfig[Cfg Flagger](defaultConfig Cfg, flags *pflag.FlagSet) func(p 
 
 func decoderConfig(target any, extraHooks DecodeHooks) *mapstructure.DecoderConfig {
 	decodeHooks := []mapstructure.DecodeHookFunc{
+		// Decode a string into any type implementing encoding.TextUnmarshaler, e.g.
+		// netip.Addr, netip.Prefix or time.Time.
+		//
+		// This must come before the slice hooks below: StringToSliceHookFunc matches on
+		// the target's reflect.Kind, so it would otherwise comma-split types that are
+		// themselves slices, such as net.IP ([]byte), before this hook ever sees them.
+		mapstructure.TextUnmarshallerHookFunc(),
+
 		// To unify the splitting of fields of a []string field across the input coming
 		// from environment, configmap and pflag (command-line), we first split a string
 		// (env/configmap) by comma, and then for all input methods we split a single

--- a/hive_test.go
+++ b/hive_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -193,6 +195,88 @@ func TestHiveStringSlice(t *testing.T) {
 	assert.ElementsMatch(t, cfg.CommasMap, expected, "unexpected CommasMap")
 	assert.ElementsMatch(t, cfg.Mixed, []string{"foo bar", "baz"}, "unexpected Mixed")
 	assert.Equal(t, cfg.StringFlag, "foo, bar, baz", "unexpected StringFlag")
+}
+
+// Level is a config field type that only implements encoding.TextUnmarshaler,
+// e.g. a type from an external package that hive knows nothing about.
+type Level int
+
+func (l *Level) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "info":
+		*l = 1
+	case "debug":
+		*l = 2
+	default:
+		return fmt.Errorf("unknown level %q", text)
+	}
+	return nil
+}
+
+type TextUnmarshalerConfig struct {
+	Addr     netip.Addr
+	Prefix   netip.Prefix
+	Time     time.Time
+	IP       net.IP
+	Level    Level
+	Prefixes []netip.Prefix
+}
+
+func (TextUnmarshalerConfig) Flags(flags *pflag.FlagSet) {
+	flags.String("addr", "", "netip.Addr")
+	flags.String("prefix", "", "netip.Prefix")
+	flags.String("time", "", "time.Time")
+
+	// net.IP is a []byte underneath, so it is only decoded correctly if the
+	// text unmarshaler hook runs before the string->[]string splitting.
+	flags.String("ip", "", "net.IP")
+
+	flags.String("level", "info", "a type implementing encoding.TextUnmarshaler")
+	flags.StringSlice("prefixes", nil, "[]netip.Prefix")
+}
+
+func TestHiveTextUnmarshaler(t *testing.T) {
+	var cfg TextUnmarshalerConfig
+	testCell := cell.Module(
+		"test",
+		"Test Module",
+		cell.Config(TextUnmarshalerConfig{}),
+		cell.Invoke(func(c TextUnmarshalerConfig) {
+			cfg = c
+		}),
+	)
+	hive := hive.New(testCell)
+
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	hive.RegisterFlags(flags)
+
+	flags.Set("addr", "10.0.0.1")
+	flags.Set("prefix", "10.0.0.0/8")
+	flags.Set("time", "2006-01-02T15:04:05Z")
+	flags.Set("ip", "10.0.0.2")
+	flags.Set("level", "debug")
+
+	// Slices of text unmarshalers are decoded element-wise, both when given
+	// via the flags as a []string and via the configmap as a plain string.
+	hive.Viper().MergeConfigMap(
+		map[string]any{
+			"prefixes": "10.0.0.0/8,192.168.0.0/16",
+		})
+
+	log := hivetest.Logger(t)
+	err := hive.Start(log, context.TODO())
+	require.NoError(t, err, "expected Start to succeed")
+	err = hive.Stop(log, context.TODO())
+	require.NoError(t, err, "expected Stop to succeed")
+
+	assert.Equal(t, netip.MustParseAddr("10.0.0.1"), cfg.Addr, "unexpected Addr")
+	assert.Equal(t, netip.MustParsePrefix("10.0.0.0/8"), cfg.Prefix, "unexpected Prefix")
+	assert.Equal(t, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC), cfg.Time, "unexpected Time")
+	assert.Equal(t, net.ParseIP("10.0.0.2"), cfg.IP, "unexpected IP")
+	assert.Equal(t, Level(2), cfg.Level, "unexpected Level")
+	assert.Equal(t,
+		[]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8"), netip.MustParsePrefix("192.168.0.0/16")},
+		cfg.Prefixes, "unexpected Prefixes")
 }
 
 type SomeObject struct {


### PR DESCRIPTION
Config struct fields whose type implements `encoding.TextUnmarshaler`, such as `netip.Addr`, `netip.Prefix` or `time.Time`, currently fail to decode with `"expected a map, got 'string'"`. Each such type needs a bespoke decode hook passed in via `DecodeHooks`. There's currently one in cilium/cilium that handles `netip.Prefix`.

This PR adds the more generic `mapstructure.TextUnmarshallerHookFunc()` to the default decode hooks so all of them work out of the box. It is placed before the slice hooks: `StringToSliceHookFunc` matches on the target's `reflect.Kind`, so it would otherwise comma-split types that are themselves slices, such as `net.IP`.

Note: This PR addresses [this TODO](https://github.com/cilium/cilium/blob/4c38f075cad5e7e7b54744c3c613f4e10fcdac0b/pkg/hive/hive.go#L146) in a more generic way than expressed in the TODO comment and will allow us to delete that bespoke decode hook once hive is bumped in cilium/cilium to a version that includes this PR.