### PR TITLE
job: Avoid deadlock when adding jobs during stopping

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -89,9 +89,14 @@ func (c *registry) Start(cell.HookContext) error {
 }
 
 func (c *registry) Stop(ctx cell.HookContext) error {
+	// Do not hold the registry mutex while waiting for jobs to stop. A runtime
+	// job may call Group.Add while handling cancellation, which also needs this
+	// mutex. The runtime lifecycle rejects additions once stopping has begun.
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.started {
+	started := c.started
+	c.mu.Unlock()
+
+	if !started {
 		return nil
 	}
 	return c.runtimeLifecycle.stop(ctx, c.logger)

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -213,6 +213,44 @@ func TestGroup_JobRuntime(t *testing.T) {
 	h.Stop(slog.Default(), context.Background())
 }
 
+func TestGroup_AddDuringStop(t *testing.T) {
+	t.Parallel()
+
+	var g Group
+	h := fixture(func(r Registry, health cell.Health, _ cell.Lifecycle) {
+		g = r.NewGroup(health)
+	})
+
+	log := hivetest.Logger(t)
+	require.NoError(t, h.Start(log, context.Background()))
+
+	parentStarted := make(chan struct{})
+	var childStarted atomic.Bool
+	g.Add(OneShot("parent", func(ctx context.Context, _ cell.Health) error {
+		close(parentStarted)
+		<-ctx.Done()
+
+		// Adding a job after cancellation must not deadlock with registry
+		// shutdown. Since shutdown has started, the child is discarded.
+		g.Add(OneShot("child", func(context.Context, cell.Health) error {
+			childStarted.Store(true)
+			return nil
+		}))
+		return nil
+	}))
+
+	select {
+	case <-parentStarted:
+	case <-time.After(timeout):
+		t.Fatal("parent job did not start")
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, h.Stop(log, stopCtx))
+	require.False(t, childStarted.Load())
+}
+
 func TestJobLifecycleOrderingAcrossGroups(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The job registry held the registry mutex when stopping the jobs which can lead to a deadlock if a job tries to add a job during the stopping.

Fix the issue by not holding the registry mutex when stopping the lifecycle. This wasn't required for anything except checking 'started'. The lifecycle had its own mutex and when it was stopping it only grabbed the mutex to collect jobs to stop so doesn't wait for a job to stop with mutex held.

AIL:3